### PR TITLE
Fix session start in login/logout

### DIFF
--- a/it490/pages/login.php
+++ b/it490/pages/login.php
@@ -1,5 +1,7 @@
 <?php
 include_once __DIR__ . '/../auth.php';
+// Ensure the session is started before handling login
+startSecureSession();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     include_once __DIR__ . '/../includes/mq_client.php';

--- a/it490/pages/logout.php
+++ b/it490/pages/logout.php
@@ -1,5 +1,7 @@
 <?php
 include_once __DIR__ . '/../auth.php';
+// Start session before attempting to destroy it
+startSecureSession();
 
 // Check if logout is confirmed
 if (isset($_GET['confirmed']) && $_GET['confirmed'] === 'true') {


### PR DESCRIPTION
## Summary
- start session before processing login
- start session before logout

## Testing
- `php -l it490/pages/login.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68543592d7e083279553993375c91c4e