### PR TITLE
Add API endpoints for users and logs

### DIFF
--- a/it490/api/connect.php
+++ b/it490/api/connect.php
@@ -1,0 +1,12 @@
+<?php
+$host = '10.0.2.15'; // IP of dev-db VM
+$user = 'BARKBUDDYUSER';
+$pass = 'SECUREPASSWORD';
+$dbname = 'BARKBUDDY';
+
+$conn = new mysqli($host, $user, $pass, $dbname);
+
+if ($conn->connect_error) {
+    die("Connection failed: " . $conn->connect_error);
+}
+?>

--- a/it490/api/logs.php
+++ b/it490/api/logs.php
@@ -1,0 +1,25 @@
+<?php
+header('Content-Type: application/json');
+require 'connect.php';
+
+$sql = "
+SELECT 
+    l.ID, u.USERNAME, l.LOG_TYPE, l.MESSAGE, l.CREATED_AT
+FROM 
+    LOGS l
+JOIN 
+    USERS u ON l.USER_ID = u.ID
+ORDER BY l.CREATED_AT DESC
+";
+
+$result = $conn->query($sql);
+$logs = [];
+
+if ($result->num_rows > 0) {
+    while ($row = $result->fetch_assoc()) {
+        $logs[] = $row;
+    }
+}
+
+echo json_encode($logs);
+?>

--- a/it490/api/users.php
+++ b/it490/api/users.php
@@ -1,0 +1,17 @@
+<?php
+header('Content-Type: application/json');
+require 'connect.php';
+
+$sql = "SELECT * FROM USERS";
+$result = $conn->query($sql);
+
+$users = [];
+
+if ($result->num_rows > 0) {
+    while ($row = $result->fetch_assoc()) {
+        $users[] = $row;
+    }
+}
+
+echo json_encode($users);
+?>


### PR DESCRIPTION
## Summary
- add DB connection script
- add endpoint to list users
- add endpoint to list logs

## Testing
- `php -l api/connect.php` *(fails: command not found)*
- `php -l api/users.php` *(fails: command not found)*
- `php -l api/logs.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68577c33e2708327bc04f1e4b4f0367d