### PR TITLE
Align MQ connections with working sample

### DIFF
--- a/it490/consumer.php
+++ b/it490/consumer.php
@@ -5,7 +5,7 @@ require __DIR__ . '/api/connect.php'; // defines $conn (MySQLi)
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
-$connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+$connection = new AMQPStreamConnection('100.87.203.113', 5672, 'JS2624', 'guest');
 $channel = $connection->channel();
 
 $channel->queue_declare('user_request_queue', false, false, false, false);

--- a/it490/includes/mq_client.php
+++ b/it490/includes/mq_client.php
@@ -39,7 +39,8 @@ function sendMessage(array $payload): array {
     }
 
     try {
-        $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+        // Use the same RabbitMQ connection details as send.php
+        $connection = new AMQPStreamConnection('100.87.203.113', 5672, 'JS2624', 'guest');
         $channel = $connection->channel();
         $channel->queue_declare('user_actions_queue', false, true, false, false);
         list($callbackQueue,) = $channel->queue_declare('', false, false, true, true);

--- a/it490/workers/mq_worker.php
+++ b/it490/workers/mq_worker.php
@@ -58,7 +58,7 @@ function checkDuplicateCredentials($conn, $username, $email, $excludeUserId = nu
     return $errors;
 }
 
-$connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+$connection = new AMQPStreamConnection('100.87.203.113', 5672, 'JS2624', 'guest');
 $channel = $connection->channel();
 $channel->queue_declare('user_actions_queue', false, true, false, false);
 $channel->queue_declare('response_queue', false, true, false, false);


### PR DESCRIPTION
## Summary
- update mq_client.php to use the same RabbitMQ host and credentials as the working send.php
- update mq_worker.php and consumer.php to use the same connection details

## Testing
- `php -l it490/consumer.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859cf808ca8832790944abdc42791f5