### PR TITLE
Align MQ connections with working sample

### DIFF
--- a/it490/consumer.php
+++ b/it490/consumer.php
@@ -5,7 +5,7 @@ require __DIR__ . '/api/connect.php'; // defines $conn (MySQLi)
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
-$connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+$connection = new AMQPStreamConnection('100.87.203.113', 5672, 'kac63', 'Linklinkm1!');
 $channel = $connection->channel();
 
 $channel->queue_declare('user_request_queue', false, false, false, false);

--- a/it490/includes/mq_client.php
+++ b/it490/includes/mq_client.php
@@ -39,7 +39,8 @@ function sendMessage(array $payload): array {
     }
 
     try {
-        $connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+        // Use the same RabbitMQ connection details as send.php
+        $connection = new AMQPStreamConnection('100.87.203.113', 5672, 'kac63', 'Linklinkm1!');
         $channel = $connection->channel();
         $channel->queue_declare('user_actions_queue', false, true, false, false);
         list($callbackQueue,) = $channel->queue_declare('', false, false, true, true);

--- a/it490/send.php
+++ b/it490/send.php
@@ -3,8 +3,8 @@ require_once __DIR__ . '/vendor/autoload.php';
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
-// Connect to RabbitMQ on dev-mq VM with username JS2624
-$connection = new AMQPStreamConnection('100.87.203.113', 5672, 'JS2624', 'guest');
+// Connect to RabbitMQ on dev-mq VM with username kac63
+$connection = new AMQPStreamConnection('100.87.203.113', 5672, 'kac63', 'Linklinkm1!');
 $channel = $connection->channel();
 
 // Create a unique callback queue

--- a/it490/workers/mq_worker.php
+++ b/it490/workers/mq_worker.php
@@ -2,8 +2,8 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../api/connect.php';
 
-use PhpAmqpLib\\Connection\\AMQPStreamConnection;
-use PhpAmqpLib\\Message\\AMQPMessage;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Message\AMQPMessage;
 
 define('PASSWORD_BCRYPT_COST', 12);
 
@@ -58,19 +58,19 @@ function checkDuplicateCredentials($conn, $username, $email, $excludeUserId = nu
     return $errors;
 }
 
-$connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+$connection = new AMQPStreamConnection('100.87.203.113', 5672, 'kac63', 'Linklinkm1!');
 $channel = $connection->channel();
 $channel->queue_declare('user_actions_queue', false, true, false, false);
 $channel->queue_declare('response_queue', false, true, false, false);
 
-echo " [*] Waiting for messages. To exit press CTRL+C\\n";
+echo " [*] Waiting for messages. To exit press CTRL+C\n";
 
 $callback = function ($msg) use ($channel, $conn) {
     try {
         $payload = json_decode($msg->body, true);
         $response = ['status' => 'error', 'message' => 'Unknown action'];
         
-        echo " [x] Processing: " . ($payload['type'] ?? 'unknown') . "\\n";
+        echo " [x] Processing: " . ($payload['type'] ?? 'unknown') . "\n";
 
         switch ($payload['type'] ?? '') {
             case 'login':
@@ -92,14 +92,14 @@ $callback = function ($msg) use ($channel, $conn) {
                                 'email' => $user['email']
                             ]
                         ];
-                        echo " [+] Login success for user: {$user['username']}\\n";
+                        echo " [+] Login success for user: {$user['username']}\n";
                     } else {
                         $response['message'] = "Invalid credentials";
-                        echo " [-] Login failed (bad password)\\n";
+                        echo " [-] Login failed (bad password)\n";
                     }
                 } else {
                     $response['message'] = "User not found";
-                    echo " [-] Login failed (user not found)\\n";
+                    echo " [-] Login failed (user not found)\n";
                 }
                 break;
 
@@ -107,7 +107,7 @@ $callback = function ($msg) use ($channel, $conn) {
                 $duplicateErrors = checkDuplicateCredentials($conn, $payload['username'], $payload['email']);
                 if (!empty($duplicateErrors)) {
                     $response['message'] = implode(", ", $duplicateErrors);
-                    echo " [-] Registration failed: " . $response['message'] . "\\n";
+                    echo " [-] Registration failed: " . $response['message'] . "\n";
                     break;
                 }
 
@@ -127,10 +127,10 @@ $callback = function ($msg) use ($channel, $conn) {
                             'email' => $payload['email']
                         ]
                     ];
-                    echo " [+] Registered user: {$payload['username']}\\n";
+                    echo " [+] Registered user: {$payload['username']}\n";
                 } else {
                     $response['message'] = "Database error: " . $conn->error;
-                    echo " [-] Registration failed: " . $response['message'] . "\\n";
+                    echo " [-] Registration failed: " . $response['message'] . "\n";
                 }
                 break;
 
@@ -143,7 +143,7 @@ $callback = function ($msg) use ($channel, $conn) {
                 $duplicateErrors = checkDuplicateCredentials($conn, $payload['username'], $payload['email'], $payload['user_id']);
                 if (!empty($duplicateErrors)) {
                     $response['message'] = implode(", ", $duplicateErrors);
-                    echo " [-] Profile update failed: " . $response['message'] . "\\n";
+                    echo " [-] Profile update failed: " . $response['message'] . "\n";
                     break;
                 }
 
@@ -175,21 +175,21 @@ $callback = function ($msg) use ($channel, $conn) {
                             'email' => $payload['email']
                         ]
                     ];
-                    echo " [+] Updated profile for user ID: {$payload['user_id']}\\n";
+                    echo " [+] Updated profile for user ID: {$payload['user_id']}\n";
                 } else {
                     $response['message'] = "Update failed: " . $conn->error;
-                    echo " [-] Profile update failed: " . $response['message'] . "\\n";
+                    echo " [-] Profile update failed: " . $response['message'] . "\n";
                 }
                 break;
 
             case 'password_reset':
                 $response['message'] = "Password reset functionality not yet implemented";
-                echo " [?] Password reset requested\\n";
+                echo " [?] Password reset requested\n";
                 break;
 
             default:
                 $response['message'] = "Unsupported action type";
-                echo " [?] Unknown message type\\n";
+                echo " [?] Unknown message type\n";
                 break;
         }
 
@@ -204,7 +204,7 @@ $callback = function ($msg) use ($channel, $conn) {
         $msg->ack();
     } catch (Exception $e) {
         error_log("Error processing message: " . $e->getMessage());
-        echo " [!] Error: " . $e->getMessage() . "\\n";
+        echo " [!] Error: " . $e->getMessage() . "\n";
     }
 };
 
@@ -216,7 +216,7 @@ try {
         $channel->wait();
     }
 } catch (Exception $e) {
-    echo "Channel error: " . $e->getMessage() . "\\n";
+    echo "Channel error: " . $e->getMessage() . "\n";
     $channel->close();
     $connection->close();
     exit(1);


### PR DESCRIPTION
## Summary
- update mq_client.php to use the same RabbitMQ host and credentials as the working send.php
- update mq_worker.php and consumer.php to use the same connection details
- fix mq_worker.php namespaces and newline logs
- switch to kac63/Linklinkm1! for all MQ connections

## Testing
- `php -l it490/send.php`
- `php -l it490/consumer.php`
- `php -l it490/workers/mq_worker.php`
- `php -l it490/includes/mq_client.php`


------
https://chatgpt.com/codex/tasks/task_e_6859cf808ca8832790944abdc42791f5