### PR TITLE
Align password reset request with worker

### DIFF
--- a/it490/pages/send-reset.php
+++ b/it490/pages/send-reset.php
@@ -7,7 +7,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST['email'])) {
 
     // Build MQ payload
     $payload = [
-        "type" => "reset_request",
+        "type" => "password_reset",
         "email" => $email
     ];
 
@@ -15,7 +15,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && isset($_POST['email'])) {
     $response = sendMessage($payload);
 
     // Set session message based on response
-    $_SESSION['message'] = $response['status'] === 'sent'
+    $_SESSION['message'] = $response['status'] === 'success'
         ? "If this email is registered, a reset link was sent to $email."
         : "Error: " . $response['message'];
 


### PR DESCRIPTION
## Summary
- switch `send-reset.php` to use the `password_reset` action
- expect `success` status from MQ worker for reset requests

## Testing
- `composer install` *(fails: command not found)*
- `php -l pages/send-reset.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d6dc734083279e5f41f3854cb157