### PR TITLE
Add admin role support

### DIFF
--- a/it490/auth.php
+++ b/it490/auth.php
@@ -55,3 +55,23 @@ function getReturnUrl(): string {
     unset($_SESSION['return_url']);
     return $url;
 }
+
+// Check if the current user has the given role
+function hasRole(string $role): bool {
+    startSecureSession();
+    return isset($_SESSION['user']['role']) && $_SESSION['user']['role'] === $role;
+}
+
+// Convenience check for admin role
+function isAdmin(): bool {
+    return hasRole('admin');
+}
+
+// Require a specific role to access a page
+function requireRole(string $role): void {
+    if (!hasRole($role)) {
+        header('HTTP/1.1 403 Forbidden');
+        echo 'Access denied';
+        exit();
+    }
+}

--- a/it490/navbar.php
+++ b/it490/navbar.php
@@ -15,6 +15,12 @@
                     </a>
                     
                     <?php if (isAuthenticated()): ?>
+                        <?php if (isAdmin()): ?>
+                        <a href="admin.php" class="nav-link">
+                            <i class="fas fa-tools"></i>
+                            <span>Admin</span>
+                        </a>
+                        <?php endif; ?>
                         <a href="profile.php" class="nav-link">
                             <i class="fas fa-user"></i>
                             <span>Profile</span>

--- a/it490/pages/admin.php
+++ b/it490/pages/admin.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/../auth.php';
+requireAuth();
+requireRole('admin');
+
+$user = $_SESSION['user'];
+$title = 'Admin Dashboard';
+include_once __DIR__ . '/../header.php';
+?>
+<div class="admin-container">
+    <h1>Admin Dashboard</h1>
+    <p>Welcome, <?= htmlspecialchars($user['username']) ?>. You have administrative access.</p>
+</div>
+<?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/pages/profile.php
+++ b/it490/pages/profile.php
@@ -34,6 +34,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <i class="fas fa-user"></i>
         </div>
         <h2>Your Profile</h2>
+        <p class="role-label">Role: <?= htmlspecialchars($user['role']) ?></p>
     </div>
 
     <?php if (!empty($success_message)): ?>


### PR DESCRIPTION
## Summary
- introduce role utilities in `auth.php`
- add Admin link and dashboard page
- display user role in profile
- extend MQ worker to store and return roles
- clean up leftover merge markers

## Testing
- `php -l auth.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bf714b248327aa4ab8f8579e46b6