### PR TITLE
Add dog profile and task management support

### DIFF
--- a/it490/header.php
+++ b/it490/header.php
@@ -10,6 +10,9 @@ $cssPath = '/it490/styles/style.css';
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="<?= $cssPath ?>">
+    <?php if (!empty($pageCss)): ?>
+    <link rel="stylesheet" href="<?= htmlspecialchars($pageCss) ?>">
+    <?php endif; ?>
 </head>
 <body>
 <?php include_once __DIR__ . '/navbar.php'; ?>

--- a/it490/includes/mq_client.php
+++ b/it490/includes/mq_client.php
@@ -39,6 +39,40 @@ function sendMessage(array $payload): array {
             }
             break;
 
+        case 'create_dog':
+            foreach (['user_id','name'] as $f) {
+                if (empty($payload[$f])) {
+                    throw new InvalidArgumentException("$f is required");
+                }
+            }
+            break;
+
+        case 'get_dogs':
+            if (empty($payload['user_id'])) {
+                throw new InvalidArgumentException('user_id is required');
+            }
+            break;
+
+        case 'add_task':
+            foreach (['dog_id','user_id','title','due_date'] as $f) {
+                if (empty($payload[$f])) {
+                    throw new InvalidArgumentException("$f is required");
+                }
+            }
+            break;
+
+        case 'get_tasks':
+            if (empty($payload['dog_id'])) {
+                throw new InvalidArgumentException('dog_id is required');
+            }
+            break;
+
+        case 'toggle_task':
+            if (empty($payload['task_id'])) {
+                throw new InvalidArgumentException('task_id is required');
+            }
+            break;
+
         case 'logout':
             if (empty($payload['user_id'])) {
                 throw new InvalidArgumentException("user_id is required for logout");

--- a/it490/includes/mq_client.php
+++ b/it490/includes/mq_client.php
@@ -79,6 +79,20 @@ function sendMessage(array $payload): array {
             }
             break;
 
+            case 'get_water':
+                if (empty($payload['dog_id'])) {
+                    throw new InvalidArgumentException('dog_id is required');
+                }
+                break;
+                
+            case 'add_water':
+                foreach (['dog_id','user_id','amount'] as $f) {
+                    if (empty($payload[$f])) {
+                        throw new InvalidArgumentException("$f is required");
+                    }
+                }
+                break;
+
         default:
             throw new InvalidArgumentException("Unsupported message type: {$payload['type']}");
     }

--- a/it490/includes/water_tracking.php
+++ b/it490/includes/water_tracking.php
@@ -1,0 +1,139 @@
+<?php
+include_once __DIR__ . '/../auth.php';
+requireAuth();
+include_once __DIR__ . '/../includes/mq_client.php';
+
+$dogId = (int)($_GET['dog_id'] ?? 0);
+if (!$dogId) {
+    header('Location: dogs.php');
+    exit();
+}
+
+// Fetch dog details
+$dogResp = sendMessage(['type' => 'get_dog', 'dog_id' => $dogId]);
+$dog = ($dogResp['status'] ?? '') === 'success' ? ($dogResp['dog'] ?? null) : null;
+
+if (!$dog || $dog['owner_id'] != $_SESSION['user']['id']) {
+    echo 'Dog not found or access denied';
+    exit();
+}
+
+// Handle form submission
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $amount = (int)($_POST['amount'] ?? 0);
+    $resp = sendMessage([
+        'type' => 'record_water',
+        'dog_id' => $dogId,
+        'amount' => $amount
+    ]);
+    
+    if (($resp['status'] ?? '') === 'success') {
+        $success = "Water intake recorded: {$amount}ml";
+        // Refresh dog data
+        $dogResp = sendMessage(['type' => 'get_dog', 'dog_id' => $dogId]);
+        $dog = ($dogResp['status'] ?? '') === 'success' ? ($dogResp['dog'] ?? $dog) : $dog;
+    } else {
+        $error = $resp['message'] ?? 'Failed to record water intake';
+    }
+}
+
+// Get water history
+$waterResp = sendMessage(['type' => 'get_water_history', 'dog_id' => $dogId]);
+$waterData = ($waterResp['status'] ?? '') === 'success' ? ($waterResp['water'] ?? []) : [];
+$percentage = ($waterResp['percentage'] ?? 0);
+
+$title = "Water Tracking - " . htmlspecialchars($dog['name']);
+include_once __DIR__ . '/../header.php';
+?>
+
+<div class="profile-container">
+    <h2>Water Tracking for <?= htmlspecialchars($dog['name']) ?></h2>
+    
+    <?php if (!empty($success)): ?>
+        <div class="alert alert-success"><?= $success ?></div>
+    <?php endif; ?>
+    
+    <?php if (!empty($error)): ?>
+        <div class="alert alert-error"><?= $error ?></div>
+    <?php endif; ?>
+
+    <div class="water-progress">
+        <h3>Today's Water Intake</h3>
+        <div class="progress-bar">
+            <div class="progress" style="width: <?= min($percentage, 100) ?>%"></div>
+            <span class="progress-text">
+                <?= ($waterData['last_water_amount'] ?? 0) ?>ml / 
+                <?= ($waterData['daily_water_goal'] ?? 1000) ?>ml
+            </span>
+        </div>
+    </div>
+
+    <form method="POST" class="water-form">
+        <div class="form-group">
+            <label for="amount">Water Amount (ml)</label>
+            <input type="number" id="amount" name="amount" min="50" max="5000" step="50" required>
+        </div>
+        <button type="submit" class="btn-water">Record Water</button>
+    </form>
+
+    <?php if (!empty($waterData['last_water_time'])): ?>
+        <div class="water-history">
+            <h4>Last Recorded</h4>
+            <p><?= date('M j, Y g:i a', strtotime($waterData['last_water_time'])) ?></p>
+        </div>
+    <?php endif; ?>
+</div>
+
+<style>
+.water-progress {
+    margin: 2rem 0;
+}
+
+.progress-bar {
+    height: 30px;
+    background: #e0e0e0;
+    border-radius: 15px;
+    position: relative;
+    overflow: hidden;
+    margin: 1rem 0;
+}
+
+.progress {
+    height: 100%;
+    background: #0077cc;
+    transition: width 0.3s ease;
+}
+
+.progress-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: #333;
+    font-weight: bold;
+}
+
+.btn-water {
+    background: #1e88e5;
+    color: white;
+    padding: 0.75rem 1.5rem;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background 0.3s;
+}
+
+.btn-water:hover {
+    background: #1565c0;
+}
+
+.water-history {
+    margin-top: 2rem;
+    padding: 1rem;
+    background: #f5f5f5;
+    border-radius: 8px;
+}
+</style>
+
+<?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/navbar.php
+++ b/it490/navbar.php
@@ -9,30 +9,30 @@
             
             <div class="navbar-menu">
                 <div class="navbar-links">
-                    <a href="landing.php" class="nav-link">
+                    <a href="/it490/pages/landing.php" class="nav-link">
                         <i class="fas fa-home"></i>
                         <span>Home</span>
                     </a>
                     
                     <?php if (isAuthenticated()): ?>
-                        <a href="profile.php" class="nav-link">
+                        <a href="/it490/pages/profile.php" class="nav-link">
                             <i class="fas fa-user"></i>
                             <span>Profile</span>
                         </a>
-                        <a href="dogs.php" class="nav-link">
+                        <a href="/it490/pages/dogs.php" class="nav-link">
                             <i class="fas fa-paw"></i>
                             <span>Dogs</span>
                         </a>
-                        <a href="logout.php" class="nav-link">
+                        <a href="/it490/pages/logout.php" class="nav-link">
                             <i class="fas fa-sign-out-alt"></i>
                             <span>Logout</span>
                         </a>
                     <?php else: ?>
-                        <a href="register.php" class="nav-link">
+                        <a href="/it490/pages/register.php" class="nav-link">
                             <i class="fas fa-user-plus"></i>
                             <span>Register</span>
                         </a>
-                        <a href="login.php" class="nav-link">
+                        <a href="/it490/pages/login.php" class="nav-link">
                             <i class="fas fa-sign-in-alt"></i>
                             <span>Login</span>
                         </a>

--- a/it490/navbar.php
+++ b/it490/navbar.php
@@ -19,6 +19,10 @@
                             <i class="fas fa-user"></i>
                             <span>Profile</span>
                         </a>
+                        <a href="dogs.php" class="nav-link">
+                            <i class="fas fa-paw"></i>
+                            <span>Dogs</span>
+                        </a>
                         <a href="logout.php" class="nav-link">
                             <i class="fas fa-sign-out-alt"></i>
                             <span>Logout</span>

--- a/it490/pages/dogs.php
+++ b/it490/pages/dogs.php
@@ -8,8 +8,9 @@ require_once __DIR__ . '/../api/connect.php';
 
 // handle add dog
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // owner_id column stores the user that owns the dog
     $stmt = $conn->prepare(
-        "INSERT INTO DOGS (user_id, name, breed, health_status, notes) VALUES (?, ?, ?, ?, ?)"
+        "INSERT INTO DOGS (owner_id, name, breed, health_status, notes) VALUES (?, ?, ?, ?, ?)"
     );
     $stmt->bind_param(
         "issss",
@@ -35,7 +36,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 // fetch dogs
 $dogs = [];
-$stmt = $conn->prepare("SELECT * FROM DOGS WHERE user_id = ?");
+$stmt = $conn->prepare("SELECT * FROM DOGS WHERE owner_id = ?");
+
 $stmt->bind_param("i", $user['id']);
 if ($stmt->execute()) {
     $res = $stmt->get_result();

--- a/it490/pages/dogs.php
+++ b/it490/pages/dogs.php
@@ -60,6 +60,7 @@ $stmt->close();
             <li>
                 <strong><?= htmlspecialchars($d['name']) ?></strong> (<?= htmlspecialchars($d['breed']) ?>)
                 - <a href="tasks.php?dog_id=<?= $d['id'] ?>">Tasks</a>
+                - <a href="water.php?dog_id=<?= $d['id'] ?>">Water</a>
             </li>
         <?php endforeach; ?>
     </ul>

--- a/it490/pages/dogs.php
+++ b/it490/pages/dogs.php
@@ -1,0 +1,52 @@
+<?php
+include_once __DIR__ . '/../auth.php';
+requireAuth();
+
+$user = $_SESSION['user'];
+include_once __DIR__ . '/../includes/mq_client.php';
+
+// handle add dog
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $payload = [
+        'type' => 'create_dog',
+        'user_id' => $user['id'],
+        'name' => trim($_POST['name']),
+        'breed' => trim($_POST['breed']),
+        'health_status' => trim($_POST['health_status']),
+        'notes' => trim($_POST['notes'])
+    ];
+    $addResponse = sendMessage($payload);
+}
+
+// fetch dogs
+$dogs = [];
+$response = sendMessage(['type' => 'get_dogs', 'user_id' => $user['id']]);
+if ($response['status'] === 'success') {
+    $dogs = $response['dogs'];
+}
+?>
+<?php $title = "My Dogs"; include_once __DIR__ . '/../header.php'; ?>
+<div class="dogs-container">
+    <h2>Your Dogs</h2>
+    <?php if (!empty($addResponse['message'])): ?>
+        <p><?= htmlspecialchars($addResponse['message']) ?></p>
+    <?php endif; ?>
+    <ul>
+        <?php foreach ($dogs as $d): ?>
+            <li>
+                <strong><?= htmlspecialchars($d['name']) ?></strong> (<?= htmlspecialchars($d['breed']) ?>)
+                - <a href="tasks.php?dog_id=<?= $d['id'] ?>">Tasks</a>
+            </li>
+        <?php endforeach; ?>
+    </ul>
+
+    <h3>Add Dog</h3>
+    <form method="POST">
+        <input type="text" name="name" placeholder="Name" required>
+        <input type="text" name="breed" placeholder="Breed">
+        <input type="text" name="health_status" placeholder="Health Status">
+        <textarea name="notes" placeholder="Care instructions"></textarea>
+        <button type="submit">Add Dog</button>
+    </form>
+</div>
+<?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/pages/dogs.php
+++ b/it490/pages/dogs.php
@@ -3,33 +3,55 @@ include_once __DIR__ . '/../auth.php';
 requireAuth();
 
 $user = $_SESSION['user'];
-include_once __DIR__ . '/../includes/mq_client.php';
+// connect directly to the database
+require_once __DIR__ . '/../api/connect.php';
 
 // handle add dog
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $payload = [
-        'type' => 'create_dog',
-        'user_id' => $user['id'],
-        'name' => trim($_POST['name']),
-        'breed' => trim($_POST['breed']),
-        'health_status' => trim($_POST['health_status']),
-        'notes' => trim($_POST['notes'])
-    ];
-    $addResponse = sendMessage($payload);
+    $stmt = $conn->prepare(
+        "INSERT INTO DOGS (user_id, name, breed, health_status, notes) VALUES (?, ?, ?, ?, ?)"
+    );
+    $stmt->bind_param(
+        "issss",
+        $user['id'],
+        $name,
+        $breed,
+        $health,
+        $notes
+    );
+
+    $name = trim($_POST['name']);
+    $breed = trim($_POST['breed']);
+    $health = trim($_POST['health_status']);
+    $notes = trim($_POST['notes']);
+
+    if ($stmt->execute()) {
+        $addMessage = 'Dog added';
+    } else {
+        $addMessage = 'Failed to create dog: ' . $conn->error;
+    }
+    $stmt->close();
 }
 
 // fetch dogs
 $dogs = [];
-$response = sendMessage(['type' => 'get_dogs', 'user_id' => $user['id']]);
-if ($response['status'] === 'success') {
-    $dogs = $response['dogs'];
+$stmt = $conn->prepare("SELECT * FROM DOGS WHERE user_id = ?");
+$stmt->bind_param("i", $user['id']);
+if ($stmt->execute()) {
+    $res = $stmt->get_result();
+    $dogs = $res->fetch_all(MYSQLI_ASSOC);
 }
+$stmt->close();
 ?>
-<?php $title = "My Dogs"; include_once __DIR__ . '/../header.php'; ?>
+<?php
+    $title = "My Dogs";
+    $pageCss = '/it490/styles/dogs.css';
+    include_once __DIR__ . '/../header.php';
+?>
 <div class="dogs-container">
     <h2>Your Dogs</h2>
-    <?php if (!empty($addResponse['message'])): ?>
-        <p><?= htmlspecialchars($addResponse['message']) ?></p>
+    <?php if (!empty($addMessage)): ?>
+        <p><?= htmlspecialchars($addMessage) ?></p>
     <?php endif; ?>
     <ul>
         <?php foreach ($dogs as $d): ?>
@@ -49,4 +71,5 @@ if ($response['status'] === 'success') {
         <button type="submit">Add Dog</button>
     </form>
 </div>
+<?php $conn->close(); ?>
 <?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/pages/tasks.php
+++ b/it490/pages/tasks.php
@@ -1,0 +1,59 @@
+<?php
+include_once __DIR__ . '/../auth.php';
+requireAuth();
+
+$user = $_SESSION['user'];
+include_once __DIR__ . '/../includes/mq_client.php';
+$dogId = intval($_GET['dog_id'] ?? 0);
+if (!$dogId) { die('Dog not specified'); }
+
+// add task
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $payload = [
+        'type' => 'add_task',
+        'dog_id' => $dogId,
+        'user_id' => $user['id'],
+        'title' => trim($_POST['title']),
+        'description' => trim($_POST['description']),
+        'due_date' => trim($_POST['due_date'])
+    ];
+    $taskResp = sendMessage($payload);
+}
+
+// toggle completion if requested
+if (isset($_GET['toggle'])) {
+    sendMessage(['type' => 'toggle_task', 'task_id' => intval($_GET['toggle'])]);
+    header('Location: tasks.php?dog_id=' . $dogId);
+    exit;
+}
+
+$tasks = [];
+$resp = sendMessage(['type' => 'get_tasks', 'dog_id' => $dogId]);
+if ($resp['status'] === 'success') { $tasks = $resp['tasks']; }
+?>
+<?php $title = "Tasks"; include_once __DIR__ . '/../header.php'; ?>
+<div class="tasks-container">
+    <h2>Tasks for Dog #<?= $dogId ?></h2>
+    <?php if (!empty($taskResp['message'])): ?>
+        <p><?= htmlspecialchars($taskResp['message']) ?></p>
+    <?php endif; ?>
+    <table>
+        <tr><th>Title</th><th>Due</th><th>Status</th><th></th></tr>
+        <?php foreach ($tasks as $t): ?>
+            <tr>
+                <td><?= htmlspecialchars($t['title']) ?></td>
+                <td><?= htmlspecialchars($t['due_date']) ?></td>
+                <td><?= $t['completed'] ? 'Done' : 'Pending' ?></td>
+                <td><a href="?dog_id=<?= $dogId ?>&toggle=<?= $t['id'] ?>">Toggle</a></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+    <h3>Add Task</h3>
+    <form method="POST">
+        <input type="text" name="title" placeholder="Title" required>
+        <input type="datetime-local" name="due_date" required>
+        <textarea name="description" placeholder="Description"></textarea>
+        <button type="submit">Add</button>
+    </form>
+</div>
+<?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/pages/water.php
+++ b/it490/pages/water.php
@@ -1,0 +1,71 @@
+<?php
+include_once __DIR__ . '/../auth.php';
+requireAuth();
+
+$user = $_SESSION['user'];
+include_once __DIR__ . '/../includes/mq_client.php';
+$dogId = intval($_GET['dog_id'] ?? 0);
+if (!$dogId) { die('Dog not specified'); }
+
+// Add water entry
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $payload = [
+        'type' => 'add_water',
+        'dog_id' => $dogId,
+        'user_id' => $user['id'],
+        'amount' => intval($_POST['amount']),
+        'notes' => trim($_POST['notes'])
+    ];
+    $waterResp = sendMessage($payload);
+}
+
+// Get water entries
+$waterEntries = [];
+$resp = sendMessage(['type' => 'get_water', 'dog_id' => $dogId]);
+if ($resp['status'] === 'success') { $waterEntries = $resp['entries']; }
+?>
+<?php
+    $title = "Water Tracking";
+    include_once __DIR__ . '/../header.php';
+?>
+<div class="water-container">
+    <h2>Water Tracking for Dog #<?= $dogId ?></h2>
+    
+    <?php if (!empty($waterResp['message'])): ?>
+        <p><?= htmlspecialchars($waterResp['message']) ?></p>
+    <?php endif; ?>
+    
+    <div class="water-entries">
+        <h3>Recent Water Entries</h3>
+        <table>
+            <tr>
+                <th>Amount (ml)</th>
+                <th>Time</th>
+                <th>Notes</th>
+            </tr>
+            <?php foreach ($waterEntries as $entry): ?>
+                <tr>
+                    <td><?= htmlspecialchars($entry['amount_ml']) ?></td>
+                    <td><?= htmlspecialchars($entry['timestamp']) ?></td>
+                    <td><?= htmlspecialchars($entry['notes']) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </table>
+    </div>
+    
+    <div class="add-water">
+        <h3>Add Water Entry</h3>
+        <form method="POST">
+            <div class="form-group">
+                <label for="amount">Amount (ml)</label>
+                <input type="number" id="amount" name="amount" required min="1">
+            </div>
+            <div class="form-group">
+                <label for="notes">Notes</label>
+                <textarea id="notes" name="notes" placeholder="Optional notes about this entry"></textarea>
+            </div>
+            <button type="submit">Add Entry</button>
+        </form>
+    </div>
+</div>
+<?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/styles/dogs.css
+++ b/it490/styles/dogs.css
@@ -1,0 +1,46 @@
+.dogs-container {
+    max-width: 600px;
+    margin: 2rem auto;
+    background: #fff;
+    padding: 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.dogs-container h2 {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.dogs-container ul {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1.5rem 0;
+}
+
+.dogs-container li {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #ddd;
+}
+
+.dogs-container form {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.dogs-container input,
+.dogs-container textarea {
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.dogs-container button {
+    width: fit-content;
+    padding: 0.5rem 1rem;
+    background: #0077cc;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}

--- a/it490/styles/style.css
+++ b/it490/styles/style.css
@@ -827,5 +827,71 @@ body {
     padding: 0.875rem 1rem;
     font-size: 1rem;
   }
-  
+  /* Water Tracking Styles */
+.water-container {
+  max-width: 800px;
+  margin: 2rem auto;
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.water-entries table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+}
+
+.water-entries th, .water-entries td {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  text-align: left;
+}
+
+.water-entries th {
+  background-color: #0077cc;
+  color: white;
+}
+
+.add-water {
+  margin-top: 2rem;
+  padding: 1rem;
+  background-color: #f8f9fa;
+  border-radius: 8px;
+}
+
+.add-water .form-group {
+  margin-bottom: 1rem;
+}
+
+.add-water label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
+
+.add-water input[type="number"] {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.add-water textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  min-height: 100px;
+}
+
+.add-water button {
+  padding: 0.5rem 1rem;
+  background-color: #0077cc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
 }

--- a/it490/workers/mq_worker.php
+++ b/it490/workers/mq_worker.php
@@ -199,7 +199,8 @@ $callback = function ($msg) use ($channel, $conn) {
                 break;
 
                         case 'create_dog':
-                            $stmt = $conn->prepare("INSERT INTO DOGS (user_id, name, breed, health_status, notes) VALUES (?, ?, ?, ?, ?)");
+                            // match database schema which stores the owner in owner_id
+                            $stmt = $conn->prepare("INSERT INTO DOGS (owner_id, name, breed, health_status, notes) VALUES (?, ?, ?, ?, ?)");
                             $stmt->bind_param("issss", $payload['user_id'], $payload['name'], $payload['breed'], $payload['health_status'], $payload['notes']);
                             if ($stmt->execute()) {
                                 $response = ['status' => 'success', 'message' => 'Dog added', 'dog_id' => $stmt->insert_id];
@@ -211,7 +212,8 @@ $callback = function ($msg) use ($channel, $conn) {
                             break;
             
                         case 'get_dogs':
-                            $stmt = $conn->prepare("SELECT * FROM DOGS WHERE user_id = ?");
+                            // return all dogs that belong to the user (owner_id)
+                            $stmt = $conn->prepare("SELECT * FROM DOGS WHERE owner_id = ?");
                             $stmt->bind_param("i", $payload['user_id']);
                             $stmt->execute();
                             $res = $stmt->get_result();

--- a/it490/workers/mq_worker.php
+++ b/it490/workers/mq_worker.php
@@ -198,6 +198,53 @@ $callback = function ($msg) use ($channel, $conn) {
                 echo " [?] Password reset requested\\n";
                 break;
 
+                        case 'create_dog':
+                            $stmt = $conn->prepare("INSERT INTO DOGS (user_id, name, breed, health_status, notes) VALUES (?, ?, ?, ?, ?)");
+                            $stmt->bind_param("issss", $payload['user_id'], $payload['name'], $payload['breed'], $payload['health_status'], $payload['notes']);
+                            if ($stmt->execute()) {
+                                $response = ['status' => 'success', 'message' => 'Dog added', 'dog_id' => $stmt->insert_id];
+                                echo " [+] Dog created id {$stmt->insert_id}\n";
+                            } else {
+                                $response['message'] = 'Failed to create dog: ' . $conn->error;
+                                echo " [-] Dog creation failed\n";
+                            }
+                            break;
+            
+                        case 'get_dogs':
+                            $stmt = $conn->prepare("SELECT * FROM DOGS WHERE user_id = ?");
+                            $stmt->bind_param("i", $payload['user_id']);
+                            $stmt->execute();
+                            $res = $stmt->get_result();
+                            $dogs = $res->fetch_all(MYSQLI_ASSOC);
+                            $response = ['status' => 'success', 'dogs' => $dogs];
+                            break;
+            
+                        case 'add_task':
+                            $stmt = $conn->prepare("INSERT INTO DOG_TASKS (dog_id, user_id, title, description, due_date) VALUES (?, ?, ?, ?, ?)");
+                            $stmt->bind_param("iisss", $payload['dog_id'], $payload['user_id'], $payload['title'], $payload['description'], $payload['due_date']);
+                            if ($stmt->execute()) {
+                                $response = ['status' => 'success', 'message' => 'Task added'];
+                                echo " [+] Task added for dog {$payload['dog_id']}\n";
+                            } else {
+                                $response['message'] = 'Failed to add task: ' . $conn->error;
+                                echo " [-] Task add failed\n";
+                            }
+                            break;
+            
+                        case 'get_tasks':
+                            $stmt = $conn->prepare("SELECT * FROM DOG_TASKS WHERE dog_id = ? ORDER BY due_date");
+                            $stmt->bind_param("i", $payload['dog_id']);
+                            $stmt->execute();
+                            $tasks = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                            $response = ['status' => 'success', 'tasks' => $tasks];
+                            break;
+            
+                        case 'toggle_task':
+                            $stmt = $conn->prepare("UPDATE DOG_TASKS SET completed = NOT completed WHERE id = ?");
+                            $stmt->bind_param("i", $payload['task_id']);
+                            $stmt->execute();
+                            $response = ['status' => 'success'];
+                            break;
             case 'logout':
                 if (!empty($payload['user_id'])) {
                     echo " [+] Logout event for user ID: {$payload['user_id']}\n";

--- a/it490/workers/mq_worker.php
+++ b/it490/workers/mq_worker.php
@@ -257,6 +257,26 @@ $callback = function ($msg) use ($channel, $conn) {
                 }
                 break;
 
+                case 'add_water':
+                    $stmt = $conn->prepare("INSERT INTO WATER_TRACKING (dog_id, user_id, amount_ml, notes) VALUES (?, ?, ?, ?)");
+                    $stmt->bind_param("iiis", $payload['dog_id'], $payload['user_id'], $payload['amount'], $payload['notes']);
+                    if ($stmt->execute()) {
+                        $response = ['status' => 'success', 'message' => 'Water entry added'];
+                        echo " [+] Water entry added for dog {$payload['dog_id']}\n";
+                    } else {
+                        $response['message'] = 'Failed to add water entry: ' . $conn->error;
+                        echo " [-] Water entry add failed\n";
+                    }
+                    break;
+                
+                case 'get_water':
+                    $stmt = $conn->prepare("SELECT * FROM WATER_TRACKING WHERE dog_id = ? ORDER BY timestamp DESC");
+                    $stmt->bind_param("i", $payload['dog_id']);
+                    $stmt->execute();
+                    $waterEntries = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+                    $response = ['status' => 'success', 'entries' => $waterEntries];
+                    break;
+
             default:
                 $response['message'] = "Unsupported action type";
                 echo " [?] Unknown message type\\n";

--- a/qa/setup_db.sh
+++ b/qa/setup_db.sh
@@ -35,6 +35,30 @@ CREATE TABLE IF NOT EXISTS USERS (
     password VARCHAR(255) NOT NULL,
     role ENUM('owner', 'sitter', 'admin') DEFAULT 'owner'
 );
+
+CREATE TABLE IF NOT EXISTS DOGS (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    breed VARCHAR(100),
+    health_status VARCHAR(255),
+    notes TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES USERS(id)
+);
+
+CREATE TABLE IF NOT EXISTS DOG_TASKS (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    dog_id INT NOT NULL,
+    user_id INT NOT NULL,
+    title VARCHAR(100) NOT NULL,
+    description TEXT,
+    due_date DATETIME,
+    completed TINYINT(1) DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (dog_id) REFERENCES DOGS(id),
+    FOREIGN KEY (user_id) REFERENCES USERS(id)
+);
 EOF
 
 echo "=== [DB SETUP] MySQL DB setup complete ==="


### PR DESCRIPTION
## Summary
- enable new message types in mq_client
- add DOGS and DOG_TASKS tables to setup script
- create pages to manage dogs and tasks
- link Dogs page in navbar
- handle dog and task actions in worker

## Testing
- `composer install`
- `php -l pages/dogs.php`
- `php -l pages/tasks.php`
- `php -l workers/mq_worker.php`
- `php -l includes/mq_client.php`


------
https://chatgpt.com/codex/tasks/task_e_688312d993248327af27fa18d7c867f4