### PR TITLE
Add admin dashboard and role support

### DIFF
--- a/it490/auth.php
+++ b/it490/auth.php
@@ -55,3 +55,9 @@ function getReturnUrl(): string {
     unset($_SESSION['return_url']);
     return $url;
 }
+
+// Check if the current user has admin role
+function isAdmin(): bool {
+    startSecureSession();
+    return isset($_SESSION['user']['role']) && $_SESSION['user']['role'] === 'admin';
+}

--- a/it490/navbar.php
+++ b/it490/navbar.php
@@ -23,6 +23,12 @@
                             <i class="fas fa-paw"></i>
                             <span>Dogs</span>
                         </a>
+                        <?php if (isAdmin()): ?>
+                        <a href="/it490/pages/admin.php" class="nav-link">
+                            <i class="fas fa-shield-alt"></i>
+                            <span>Admin</span>
+                        </a>
+                        <?php endif; ?>
                         <a href="/it490/pages/logout.php" class="nav-link">
                             <i class="fas fa-sign-out-alt"></i>
                             <span>Logout</span>

--- a/it490/pages/admin.php
+++ b/it490/pages/admin.php
@@ -1,0 +1,58 @@
+<?php
+require_once __DIR__ . '/../auth.php';
+requireAuth();
+
+if (!isAdmin()) {
+    header('HTTP/1.1 403 Forbidden');
+    echo 'Access denied';
+    exit();
+}
+
+require_once __DIR__ . '/../api/connect.php';
+
+// Fetch users
+$users = [];
+$res = $conn->query("SELECT id, username, email, role FROM USERS ORDER BY id");
+if ($res) {
+    $users = $res->fetch_all(MYSQLI_ASSOC);
+}
+
+// Fetch logs
+$logs = [];
+$logRes = $conn->query("SELECT l.ID, u.USERNAME, l.LOG_TYPE, l.MESSAGE, l.CREATED_AT FROM LOGS l JOIN USERS u ON l.USER_ID = u.ID ORDER BY l.CREATED_AT DESC LIMIT 100");
+if ($logRes) {
+    $logs = $logRes->fetch_all(MYSQLI_ASSOC);
+}
+
+$title = 'Admin Dashboard';
+include_once __DIR__ . '/../header.php';
+?>
+<div class="admin-container">
+    <h2>User Management</h2>
+    <table class="admin-table">
+        <tr><th>ID</th><th>Username</th><th>Email</th><th>Role</th></tr>
+        <?php foreach ($users as $u): ?>
+            <tr>
+                <td><?= htmlspecialchars($u['id']) ?></td>
+                <td><?= htmlspecialchars($u['username']) ?></td>
+                <td><?= htmlspecialchars($u['email']) ?></td>
+                <td><?= htmlspecialchars($u['role']) ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+
+    <h2>Recent Logs</h2>
+    <table class="admin-table">
+        <tr><th>ID</th><th>User</th><th>Type</th><th>Message</th><th>Time</th></tr>
+        <?php foreach ($logs as $log): ?>
+            <tr>
+                <td><?= htmlspecialchars($log['ID']) ?></td>
+                <td><?= htmlspecialchars($log['USERNAME']) ?></td>
+                <td><?= htmlspecialchars($log['LOG_TYPE']) ?></td>
+                <td><?= htmlspecialchars($log['MESSAGE']) ?></td>
+                <td><?= htmlspecialchars($log['CREATED_AT']) ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+</div>
+<?php include_once __DIR__ . '/../footer.php'; ?>


### PR DESCRIPTION
## Summary
- support storing user role in session
- add admin role check helper
- return user role from MQ worker on login, register, and profile update
- add admin link in navbar for admins
- implement `/pages/admin.php` dashboard to view users and logs

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_688a9b495a248327b2c17305e12e0943