### PR TITLE
Fix water tracking page

### DIFF
--- a/it490/pages/water.php
+++ b/it490/pages/water.php
@@ -7,7 +7,9 @@ include_once __DIR__ . '/../includes/mq_client.php';
 $dogId = intval($_GET['dog_id'] ?? 0);
 if (!$dogId) { die('Dog not specified'); }
 
-// Add water entry
+$waterResp = [];
+
+// Add water entry using PRG pattern
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $payload = [
         'type' => 'add_water',
@@ -17,6 +19,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'notes' => trim($_POST['notes'])
     ];
     $waterResp = sendMessage($payload);
+    if ($waterResp['status'] === 'success') {
+        $msg = urlencode($waterResp['message'] ?? '');
+        header("Location: water.php?dog_id={$dogId}&msg={$msg}");
+        exit;
+    }
+}
+
+if (isset($_GET['msg'])) {
+    $waterResp['message'] = $_GET['msg'];
 }
 
 // Get water entries


### PR DESCRIPTION
## Summary
- ensure water form uses Post/Redirect/Get pattern
- initialize water form response variable to avoid warnings

## Testing
- `php -l it490/pages/water.php`
- `find it490 -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_688ab2212ca083278854c70a08b18b24