### PR TITLE
Implement care logs, medication and behavior tracking

### DIFF
--- a/it490/includes/mq_client.php
+++ b/it490/includes/mq_client.php
@@ -85,13 +85,67 @@ function sendMessage(array $payload): array {
                 }
                 break;
                 
-            case 'add_water':
-                foreach (['dog_id','user_id','amount'] as $f) {
-                    if (empty($payload[$f])) {
-                        throw new InvalidArgumentException("$f is required");
-                    }
+        case 'add_water':
+            foreach (['dog_id','user_id','amount'] as $f) {
+                if (empty($payload[$f])) {
+                    throw new InvalidArgumentException("$f is required");
                 }
-                break;
+            }
+            break;
+
+        case 'add_care_log':
+            foreach (['dog_id','user_id','note'] as $f) {
+                if (empty($payload[$f])) {
+                    throw new InvalidArgumentException("$f is required");
+                }
+            }
+            break;
+
+        case 'get_care_logs':
+            if (empty($payload['dog_id'])) {
+                throw new InvalidArgumentException('dog_id is required');
+            }
+            break;
+
+        case 'schedule_medication':
+            foreach (['dog_id','user_id','medication','schedule_time'] as $f) {
+                if (empty($payload[$f])) {
+                    throw new InvalidArgumentException("$f is required");
+                }
+            }
+            break;
+
+        case 'complete_medication':
+            if (empty($payload['med_id'])) {
+                throw new InvalidArgumentException('med_id is required');
+            }
+            break;
+
+        case 'get_medications':
+            if (empty($payload['dog_id'])) {
+                throw new InvalidArgumentException('dog_id is required');
+            }
+            break;
+
+        case 'add_behavior':
+            foreach (['dog_id','user_id','behavior'] as $f) {
+                if (empty($payload[$f])) {
+                    throw new InvalidArgumentException("$f is required");
+                }
+            }
+            break;
+
+        case 'get_behaviors':
+            if (empty($payload['dog_id'])) {
+                throw new InvalidArgumentException('dog_id is required');
+            }
+            break;
+
+        case 'get_points':
+            if (empty($payload['user_id'])) {
+                throw new InvalidArgumentException('user_id is required');
+            }
+            break;
 
         default:
             throw new InvalidArgumentException("Unsupported message type: {$payload['type']}");

--- a/it490/navbar.php
+++ b/it490/navbar.php
@@ -23,6 +23,10 @@
                             <i class="fas fa-paw"></i>
                             <span>Dogs</span>
                         </a>
+                        <a href="/it490/pages/gamification.php" class="nav-link">
+                            <i class="fas fa-star"></i>
+                            <span>Points</span>
+                        </a>
                         <a href="/it490/pages/logout.php" class="nav-link">
                             <i class="fas fa-sign-out-alt"></i>
                             <span>Logout</span>

--- a/it490/pages/behavior.php
+++ b/it490/pages/behavior.php
@@ -1,0 +1,57 @@
+<?php
+include_once __DIR__ . '/../auth.php';
+requireAuth();
+
+$user = $_SESSION['user'];
+include_once __DIR__ . '/../includes/mq_client.php';
+
+$dogId = intval($_GET['dog_id'] ?? 0);
+if (!$dogId) { die('Dog not specified'); }
+
+$behResp = [];
+$msg = trim($_GET['msg'] ?? '');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $payload = [
+        'type' => 'add_behavior',
+        'dog_id' => $dogId,
+        'user_id' => $user['id'],
+        'behavior' => trim($_POST['behavior']),
+        'notes' => trim($_POST['notes'])
+    ];
+    $behResp = sendMessage($payload);
+    $redirectMsg = urlencode($behResp['message'] ?? '');
+    header("Location: behavior.php?dog_id={$dogId}&msg={$redirectMsg}");
+    exit();
+}
+
+if ($msg) { $behResp['message'] = $msg; }
+
+$entries = [];
+$resp = sendMessage(['type' => 'get_behaviors', 'dog_id' => $dogId]);
+if ($resp['status'] === 'success') { $entries = $resp['behaviors']; }
+?>
+<?php $title = "Behavior"; include_once __DIR__ . '/../header.php'; ?>
+<div class="behavior-container">
+    <h2>Behavior Logs for Dog #<?= $dogId ?></h2>
+    <?php if (!empty($behResp['message'])): ?>
+        <p><?= htmlspecialchars($behResp['message']) ?></p>
+    <?php endif; ?>
+    <table>
+        <tr><th>Behavior</th><th>Notes</th><th>Time</th></tr>
+        <?php foreach ($entries as $e): ?>
+            <tr>
+                <td><?= htmlspecialchars($e['behavior']) ?></td>
+                <td><?= htmlspecialchars($e['notes']) ?></td>
+                <td><?= htmlspecialchars($e['created_at']) ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+    <h3>Add Entry</h3>
+    <form method="POST">
+        <input type="text" name="behavior" placeholder="Behavior" required>
+        <textarea name="notes" placeholder="Notes"></textarea>
+        <button type="submit">Add</button>
+    </form>
+</div>
+<?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/pages/care.php
+++ b/it490/pages/care.php
@@ -1,0 +1,63 @@
+<?php
+include_once __DIR__ . '/../auth.php';
+requireAuth();
+
+$user = $_SESSION['user'];
+include_once __DIR__ . '/../includes/mq_client.php';
+
+$dogId = intval($_GET['dog_id'] ?? 0);
+if (!$dogId) {
+    die('Dog not specified');
+}
+
+$careResp = [];
+$msg = trim($_GET['msg'] ?? '');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $payload = [
+        'type' => 'add_care_log',
+        'dog_id' => $dogId,
+        'user_id' => $user['id'],
+        'note' => trim($_POST['note'])
+    ];
+    $careResp = sendMessage($payload);
+    $redirectMsg = urlencode($careResp['message'] ?? '');
+    header("Location: care.php?dog_id={$dogId}&msg={$redirectMsg}");
+    exit();
+}
+
+if ($msg) {
+    $careResp['message'] = $msg;
+}
+
+$logs = [];
+$resp = sendMessage(['type' => 'get_care_logs', 'dog_id' => $dogId]);
+if ($resp['status'] === 'success') {
+    $logs = $resp['logs'];
+}
+?>
+<?php
+$title = "Care Logs";
+include_once __DIR__ . '/../header.php';
+?>
+<div class="care-container">
+    <h2>Care Logs for Dog #<?= $dogId ?></h2>
+    <?php if (!empty($careResp['message'])): ?>
+        <p><?= htmlspecialchars($careResp['message']) ?></p>
+    <?php endif; ?>
+    <table>
+        <tr><th>Note</th><th>Time</th></tr>
+        <?php foreach ($logs as $l): ?>
+            <tr>
+                <td><?= htmlspecialchars($l['note']) ?></td>
+                <td><?= htmlspecialchars($l['created_at']) ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+    <h3>Add Log</h3>
+    <form method="POST">
+        <textarea name="note" required></textarea>
+        <button type="submit">Add</button>
+    </form>
+</div>
+<?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/pages/dogs.php
+++ b/it490/pages/dogs.php
@@ -61,6 +61,9 @@ $stmt->close();
                 <strong><?= htmlspecialchars($d['name']) ?></strong> (<?= htmlspecialchars($d['breed']) ?>)
                 - <a href="tasks.php?dog_id=<?= $d['id'] ?>">Tasks</a>
                 - <a href="water.php?dog_id=<?= $d['id'] ?>">Water</a>
+                - <a href="care.php?dog_id=<?= $d['id'] ?>">Care Logs</a>
+                - <a href="medications.php?dog_id=<?= $d['id'] ?>">Medications</a>
+                - <a href="behavior.php?dog_id=<?= $d['id'] ?>">Behavior</a>
             </li>
         <?php endforeach; ?>
     </ul>

--- a/it490/pages/gamification.php
+++ b/it490/pages/gamification.php
@@ -1,0 +1,15 @@
+<?php
+include_once __DIR__ . '/../auth.php';
+requireAuth();
+include_once __DIR__ . '/../includes/mq_client.php';
+
+$user = $_SESSION['user'];
+$resp = sendMessage(['type' => 'get_points', 'user_id' => $user['id']]);
+$points = ($resp['status'] === 'success') ? $resp['points'] : 0;
+?>
+<?php $title = "Gamification"; include_once __DIR__ . '/../header.php'; ?>
+<div class="points-container">
+    <h2>Your Points</h2>
+    <p><?= $points ?></p>
+</div>
+<?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/pages/medications.php
+++ b/it490/pages/medications.php
@@ -1,0 +1,69 @@
+<?php
+include_once __DIR__ . '/../auth.php';
+requireAuth();
+
+$user = $_SESSION['user'];
+include_once __DIR__ . '/../includes/mq_client.php';
+
+$dogId = intval($_GET['dog_id'] ?? 0);
+if (!$dogId) { die('Dog not specified'); }
+
+$medResp = [];
+$msg = trim($_GET['msg'] ?? '');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $payload = [
+        'type' => 'schedule_medication',
+        'dog_id' => $dogId,
+        'user_id' => $user['id'],
+        'medication' => trim($_POST['medication']),
+        'dosage' => trim($_POST['dosage']),
+        'schedule_time' => trim($_POST['schedule_time']),
+        'notes' => trim($_POST['notes'])
+    ];
+    $medResp = sendMessage($payload);
+    $redirectMsg = urlencode($medResp['message'] ?? '');
+    header("Location: medications.php?dog_id={$dogId}&msg={$redirectMsg}");
+    exit();
+}
+
+if ($msg) { $medResp['message'] = $msg; }
+
+$meds = [];
+$resp = sendMessage(['type' => 'get_medications', 'dog_id' => $dogId]);
+if ($resp['status'] === 'success') { $meds = $resp['medications']; }
+
+if (isset($_GET['complete'])) {
+    sendMessage(['type' => 'complete_medication', 'med_id' => intval($_GET['complete'])]);
+    header('Location: medications.php?dog_id=' . $dogId);
+    exit();
+}
+?>
+<?php $title = "Medications"; include_once __DIR__ . '/../header.php'; ?>
+<div class="med-container">
+    <h2>Medication Schedule for Dog #<?= $dogId ?></h2>
+    <?php if (!empty($medResp['message'])): ?>
+        <p><?= htmlspecialchars($medResp['message']) ?></p>
+    <?php endif; ?>
+    <table>
+        <tr><th>Medication</th><th>Dosage</th><th>Time</th><th>Status</th><th></th></tr>
+        <?php foreach ($meds as $m): ?>
+            <tr>
+                <td><?= htmlspecialchars($m['medication']) ?></td>
+                <td><?= htmlspecialchars($m['dosage']) ?></td>
+                <td><?= htmlspecialchars($m['schedule_time']) ?></td>
+                <td><?= $m['completed'] ? 'Done' : 'Pending' ?></td>
+                <td><?php if(!$m['completed']): ?><a href="?dog_id=<?= $dogId ?>&complete=<?= $m['id'] ?>">Mark Done</a><?php endif; ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+    <h3>Schedule Medication</h3>
+    <form method="POST">
+        <input type="text" name="medication" placeholder="Medication" required>
+        <input type="text" name="dosage" placeholder="Dosage">
+        <input type="datetime-local" name="schedule_time" required>
+        <textarea name="notes" placeholder="Notes"></textarea>
+        <button type="submit">Add</button>
+    </form>
+</div>
+<?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/workers/mq_worker.php
+++ b/it490/workers/mq_worker.php
@@ -295,6 +295,9 @@ $callback = function ($msg) use ($channel, $conn) {
                     $stmt->bind_param("iis", $payload['dog_id'], $payload['user_id'], $payload['note']);
                     if ($stmt->execute()) {
                         $response = ['status' => 'success', 'message' => 'Care log added'];
+                        $stmt = $conn->prepare("INSERT INTO USER_POINTS (user_id, points) VALUES (?, 5) ON DUPLICATE KEY UPDATE points = points + 5");
+                        $stmt->bind_param("i", $payload['user_id']);
+                        $stmt->execute();
                     } else {
                         $response['message'] = 'Failed to add care log: ' . $conn->error;
                     }
@@ -313,6 +316,9 @@ $callback = function ($msg) use ($channel, $conn) {
                     $stmt->bind_param("iissss", $payload['dog_id'], $payload['user_id'], $payload['medication'], $payload['dosage'], $payload['schedule_time'], $payload['notes']);
                     if ($stmt->execute()) {
                         $response = ['status' => 'success', 'message' => 'Medication scheduled'];
+                        $stmt = $conn->prepare("INSERT INTO USER_POINTS (user_id, points) VALUES (?, 5) ON DUPLICATE KEY UPDATE points = points + 5");
+                        $stmt->bind_param("i", $payload['user_id']);
+                        $stmt->execute();
                     } else {
                         $response['message'] = 'Failed to schedule medication: ' . $conn->error;
                     }
@@ -323,6 +329,17 @@ $callback = function ($msg) use ($channel, $conn) {
                     $stmt->bind_param("i", $payload['med_id']);
                     $stmt->execute();
                     $response = ['status' => 'success'];
+                    if ($stmt->affected_rows > 0) {
+                        $stmt = $conn->prepare("SELECT user_id FROM MEDICATION_SCHEDULES WHERE id = ?");
+                        $stmt->bind_param("i", $payload['med_id']);
+                        $stmt->execute();
+                        $uid = $stmt->get_result()->fetch_assoc()['user_id'] ?? 0;
+                        if ($uid) {
+                            $stmt = $conn->prepare("INSERT INTO USER_POINTS (user_id, points) VALUES (?, 5) ON DUPLICATE KEY UPDATE points = points + 5");
+                            $stmt->bind_param("i", $uid);
+                            $stmt->execute();
+                        }
+                    }
                     break;
 
                 case 'get_medications':
@@ -338,6 +355,9 @@ $callback = function ($msg) use ($channel, $conn) {
                     $stmt->bind_param("iiss", $payload['dog_id'], $payload['user_id'], $payload['behavior'], $payload['notes']);
                     if ($stmt->execute()) {
                         $response = ['status' => 'success', 'message' => 'Behavior entry added'];
+                        $stmt = $conn->prepare("INSERT INTO USER_POINTS (user_id, points) VALUES (?, 5) ON DUPLICATE KEY UPDATE points = points + 5");
+                        $stmt->bind_param("i", $payload['user_id']);
+                        $stmt->execute();
                     } else {
                         $response['message'] = 'Failed to add behavior entry: ' . $conn->error;
                     }

--- a/qa/setup_db.sh
+++ b/qa/setup_db.sh
@@ -59,6 +59,48 @@ CREATE TABLE IF NOT EXISTS DOG_TASKS (
     FOREIGN KEY (dog_id) REFERENCES DOGS(id),
     FOREIGN KEY (user_id) REFERENCES USERS(id)
 );
+
+# New tables for care logs, medication scheduling, behavior tracking, and user points
+CREATE TABLE IF NOT EXISTS CARE_LOGS (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    dog_id INT NOT NULL,
+    user_id INT NOT NULL,
+    note TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (dog_id) REFERENCES DOGS(id),
+    FOREIGN KEY (user_id) REFERENCES USERS(id)
+);
+
+CREATE TABLE IF NOT EXISTS MEDICATION_SCHEDULES (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    dog_id INT NOT NULL,
+    user_id INT NOT NULL,
+    medication VARCHAR(100) NOT NULL,
+    dosage VARCHAR(100),
+    schedule_time DATETIME,
+    notes TEXT,
+    completed TINYINT(1) DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (dog_id) REFERENCES DOGS(id),
+    FOREIGN KEY (user_id) REFERENCES USERS(id)
+);
+
+CREATE TABLE IF NOT EXISTS BEHAVIOR_LOGS (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    dog_id INT NOT NULL,
+    user_id INT NOT NULL,
+    behavior VARCHAR(255) NOT NULL,
+    notes TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (dog_id) REFERENCES DOGS(id),
+    FOREIGN KEY (user_id) REFERENCES USERS(id)
+);
+
+CREATE TABLE IF NOT EXISTS USER_POINTS (
+    user_id INT PRIMARY KEY,
+    points INT DEFAULT 0,
+    FOREIGN KEY (user_id) REFERENCES USERS(id)
+);
 EOF
 
 echo "=== [DB SETUP] MySQL DB setup complete ==="


### PR DESCRIPTION
## Summary
- add DB tables for care logs, medications, behaviors and user points
- extend MQ worker with handlers for new actions and points on task completion
- validate new message types in `mq_client.php`
- add pages for care logs, medication scheduling, behavior logging and gamification
- link new features in dogs list and navbar

## Testing
- `php -l qa/setup_db.sh`
- `php -l it490/workers/mq_worker.php`
- `php -l it490/includes/mq_client.php`
- `php -l it490/pages/care.php`
- `php -l it490/pages/medications.php`
- `php -l it490/pages/behavior.php`
- `php -l it490/pages/gamification.php`
- `php -l it490/pages/dogs.php`
- `php -l it490/navbar.php`


------
https://chatgpt.com/codex/tasks/task_e_688ac939fc1c8327b765a90543c3b169