### PR TITLE
Fix unsupported get_dog action

### DIFF
--- a/it490/includes/mq_client.php
+++ b/it490/includes/mq_client.php
@@ -53,6 +53,12 @@ function sendMessage(array $payload): array {
             }
             break;
 
+        case 'get_dog':
+            if (empty($payload['dog_id'])) {
+                throw new InvalidArgumentException('dog_id is required');
+            }
+            break;
+
         case 'add_task':
             foreach (['dog_id','user_id','title','due_date'] as $f) {
                 if (empty($payload[$f])) {

--- a/it490/workers/mq_worker.php
+++ b/it490/workers/mq_worker.php
@@ -234,6 +234,18 @@ $callback = function ($msg) use ($channel, $conn) {
                             $dogs = $res->fetch_all(MYSQLI_ASSOC);
                             $response = ['status' => 'success', 'dogs' => $dogs];
                             break;
+
+                        case 'get_dog':
+                            $stmt = $conn->prepare("SELECT * FROM DOGS WHERE id = ?");
+                            $stmt->bind_param("i", $payload['dog_id']);
+                            $stmt->execute();
+                            $dog = $stmt->get_result()->fetch_assoc();
+                            if ($dog) {
+                                $response = ['status' => 'success', 'dog' => $dog];
+                            } else {
+                                $response['message'] = 'Dog not found';
+                            }
+                            break;
             
                         case 'add_task':
                             $stmt = $conn->prepare("INSERT INTO DOG_TASKS (dog_id, user_id, title, description, due_date) VALUES (?, ?, ?, ?, ?)");


### PR DESCRIPTION
## Summary
- accept `get_dog` messages in MQ client
- implement `get_dog` case in worker

## Testing
- `composer install`
- `php -l includes/mq_client.php`
- `php -l it490/workers/mq_worker.php`


------
https://chatgpt.com/codex/tasks/task_e_688c49476240832783975c491d25d86a