### PR TITLE
Fix action type handling

### DIFF
--- a/it490/includes/mq_client.php
+++ b/it490/includes/mq_client.php
@@ -10,6 +10,8 @@ function sendMessage(array $payload): array {
         throw new InvalidArgumentException('Payload must contain a type');
     }
 
+    $payload['type'] = strtolower(trim($payload['type']));
+
     switch ($payload['type']) {
         case 'login':
             if (empty($payload['username']) || empty($payload['password'])) {
@@ -50,6 +52,12 @@ function sendMessage(array $payload): array {
         case 'get_dogs':
             if (empty($payload['user_id'])) {
                 throw new InvalidArgumentException('user_id is required');
+            }
+            break;
+
+        case 'get_dog':
+            if (empty($payload['dog_id'])) {
+                throw new InvalidArgumentException('dog_id is required');
             }
             break;
 


### PR DESCRIPTION
## Summary
- trim and lower-case incoming action types in MQ client and worker
- show unknown message type in worker logs for easier debugging

## Testing
- `composer install`
- `php -l includes/mq_client.php`
- `php -l workers/mq_worker.php`


------
https://chatgpt.com/codex/tasks/task_e_688c49476240832783975c491d25d86a