### PR TITLE
Handle lost dog updates and show playdate request messages

### DIFF
--- a/it490/pages/lost_dogs.php
+++ b/it490/pages/lost_dogs.php
@@ -5,8 +5,10 @@ requireAuth();
 $user = $_SESSION['user'];
 include_once __DIR__ . '/../includes/mq_client.php';
 
+$message = $_SESSION['message'] ?? '';
+unset($_SESSION['message']);
+
 // Handle form submission
-$message = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $resp = sendMessage([
         'type'    => 'lost_dogs_create',
@@ -19,7 +21,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'photo_url'=> trim($_POST['photo_url']),
         'description'=> trim($_POST['description']),
     ]);
-    $message = $resp['message'] ?? '';
+    $message = $resp['message'] ?? $message;
 }
 
 // Fetch active alerts
@@ -80,7 +82,8 @@ include_once __DIR__ . '/../header.php';
                 <img src="<?= htmlspecialchars($a['photo_url']) ?>" class="thumbnail" alt="Lost dog photo" />
             <?php endif; ?>
             <p><?= htmlspecialchars($a['description']) ?></p>
-            <form method="POST" action="../send_user_request.php?type=lost_dogs_update" class="form-inline">
+            <form method="POST" action="../send_user_request.php" class="form-inline">
+                <input type="hidden" name="type" value="lost_dogs_update" />
                 <input type="hidden" name="id" value="<?= htmlspecialchars($a['id']) ?>" />
                 <button name="status" value="found" class="btn small">Mark Found</button>
             </form>

--- a/it490/pages/playdate_request.php
+++ b/it490/pages/playdate_request.php
@@ -2,26 +2,28 @@
 include_once __DIR__ . '/../auth.php';
 requireAuth();
 $user = $_SESSION['user'];
-<<<<<<< HEAD
-include_once __DIR__ . '/../includes/.mq_client.php';
-=======
 include_once __DIR__ . '/../includes/mq_client.php';
->>>>>>> 48f3e61 (modified playdates)
 
 // fetch requests
 $resp = sendMessage(['type'=>'playdate_requests_list','user_id'=>$user['id']]);
 $reqs = $resp['requests'] ?? [];
+$message = $_SESSION['message'] ?? '';
+unset($_SESSION['message']);
 
 $title = 'Playdate Requests';
 include_once __DIR__ . '/../header.php';
 ?>
 <div class="container">
   <h1>Incoming Playdate Requests</h1>
+  <?php if (!empty($message)): ?>
+  <div class="alert"><?= htmlspecialchars($message) ?></div>
+  <?php endif; ?>
   <ul class="list">
     <?php foreach ($reqs as $r): ?>
     <li>
       <p>From user <?= htmlspecialchars($r['requester_id']) ?>: <?= htmlspecialchars($r['custom_message']) ?></p>
-      <form method="POST" action="../send_user_request.php?type=playdate_requests_update" class="form-inline">
+      <form method="POST" action="../send_user_request.php" class="form-inline">
+        <input type="hidden" name="type" value="playdate_requests_update">
         <input type="hidden" name="id" value="<?= htmlspecialchars($r['id']) ?>">
         <button name="status" value="accepted" class="btn small">Accept</button>
         <button name="status" value="declined" class="btn small">Decline</button>

--- a/it490/pages/playdates.php
+++ b/it490/pages/playdates.php
@@ -17,8 +17,8 @@ foreach ([
 // fetch playdates
 $resp = sendMessage(array_merge(['type'=>'playdates_list'], $filters));
 $playdates = $resp['playdates'] ?? [];
-
-$message = '';
+$message = $_SESSION['message'] ?? '';
+unset($_SESSION['message']);
 
 // handle create submission
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -96,7 +96,8 @@ include_once __DIR__ . '/../header.php';
       <h3><?= htmlspecialchars($p['title']) ?></h3>
       <p><?= htmlspecialchars($p['scheduled_at']) ?> @ <?= htmlspecialchars($p['location']) ?></p>
       <p><?= htmlspecialchars($p['description']) ?></p>
-      <form method="POST" action="../send_user_request.php?type=playdate_request" class="form-inline">
+      <form method="POST" action="../send_user_request.php" class="form-inline">
+        <input type="hidden" name="type" value="playdate_request">
         <input type="hidden" name="target_owner_id" value="<?= htmlspecialchars($p['created_by']) ?>">
         <input type="hidden" name="dog_size_match" value="Medium">
         <input name="location_preference" placeholder="Location" required class="input">

--- a/it490/send_user_request.php
+++ b/it490/send_user_request.php
@@ -6,8 +6,9 @@ $user = $_SESSION['user'];
 include_once __DIR__ . '/includes/mq_client.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $type = $_GET['type'] ?? '';
-    
+    $type = $_POST['type'] ?? $_GET['type'] ?? '';
+    $redirect = '/it490/pages/playdates.php';
+
     if ($type === 'playdate_request') {
         $resp = sendMessage([
             'type' => 'playdate_request',
@@ -17,15 +18,48 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             'location_preference' => $_POST['location_preference'],
             'custom_message' => $_POST['custom_message'] ?? ''
         ]);
-        
+
         if ($resp['status'] === 'success') {
             $_SESSION['message'] = 'Playdate request sent successfully!';
         } else {
             $_SESSION['message'] = $resp['message'] ?? 'Failed to send request';
         }
+    } elseif ($type === 'playdate_requests_update') {
+        $resp = sendMessage([
+            'type' => 'playdate_requests_update',
+            'id' => $_POST['id'],
+            'status' => $_POST['status']
+        ]);
+
+        if ($resp['status'] === 'success') {
+            $_SESSION['message'] = 'Request updated';
+        } else {
+            $_SESSION['message'] = $resp['message'] ?? 'Failed to update request';
+        }
+
+        $redirect = '/it490/pages/playdate_request.php';
+    } elseif ($type === 'lost_dogs_update') {
+        $resp = sendMessage([
+            'type' => 'lost_dogs_update',
+            'id'   => $_POST['id'],
+            'status' => $_POST['status']
+        ]);
+
+        if ($resp['status'] === 'success') {
+            $_SESSION['message'] = 'Alert updated';
+        } else {
+            $_SESSION['message'] = $resp['message'] ?? 'Failed to update alert';
+        }
+
+        $redirect = '/it490/pages/lost_dogs.php';
+    } else {
+        $_SESSION['message'] = 'Unsupported action type';
     }
+
+    header("Location: {$redirect}");
+    exit();
 }
 
-header('Location: /pages/playdates.php');
+header('Location: /it490/pages/playdates.php');
 exit();
 ?>


### PR DESCRIPTION
## Summary
- display session feedback on playdate request page
- support lost dog status updates and surface flash messages
- guard against unsupported request actions
- send action type via POST to avoid unsupported action type errors
- show playdate request feedback after redirects

## Testing
- `php -l it490/pages/playdates.php`
- `php -l it490/send_user_request.php`
- `php -l it490/pages/playdate_request.php`
- `php -l it490/pages/lost_dogs.php`


------
https://chatgpt.com/codex/tasks/task_e_688fdf31daf0832781f4e04e407b35ec