### PR TITLE
Add sitter invite and playdate request support

### DIFF
--- a/it490/includes/mq_client.php
+++ b/it490/includes/mq_client.php
@@ -117,12 +117,15 @@ function sendMessage(array $payload): array {
         case 'playdates_create':
             foreach ([
                 'user_id', 'title', 'scheduled_at', 'location', 'age_range',
-                'size', 'energy_level', 'temperament', 'play_style', 'gender_pref', 'description'
+                'size', 'energy_level', 'temperament', 'gender_pref'
             ] as $f) {
                 if (empty($payload[$f])) {
                     throw new InvalidArgumentException("$f is required");
                 }
             }
+            // optional fields
+            $payload['play_style'] = $payload['play_style'] ?? '';
+            $payload['description'] = $payload['description'] ?? '';
             break;
 
         case 'playdates_list':

--- a/it490/includes/mq_client.php
+++ b/it490/includes/mq_client.php
@@ -109,10 +109,8 @@ function sendMessage(array $payload): array {
             break;
 
         case 'invite_update':
-            foreach (['id','status'] as $f) {
-                if (empty($payload[$f])) {
-                    throw new InvalidArgumentException("$f is required");
-                }
+            if (empty($payload['status']) || (empty($payload['id']) && empty($payload['code']))) {
+                throw new InvalidArgumentException('status and id or code are required');
             }
             break;
 

--- a/it490/pages/accept_invite.php
+++ b/it490/pages/accept_invite.php
@@ -1,0 +1,31 @@
+<?php
+include_once __DIR__ . '/../auth.php';
+requireAuth();
+$user = $_SESSION['user'];
+include_once __DIR__ . '/../includes/mq_client.php';
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $resp = sendMessage([
+        'type' => 'invite_update',
+        'code' => trim($_POST['code']),
+        'status' => 'accepted',
+        'accepted_by' => $user['id']
+    ]);
+    $message = $resp['message'] ?? '';
+}
+
+$title = 'Accept Invitation';
+include_once __DIR__ . '/../header.php';
+?>
+<div class="container">
+  <h1>Accept Invitation</h1>
+  <?php if (!empty($message)): ?>
+    <div class="alert"><?= htmlspecialchars($message) ?></div>
+  <?php endif; ?>
+  <form method="POST" class="form">
+    <input name="code" placeholder="Invitation Code" required class="input">
+    <button type="submit" class="btn">Accept</button>
+  </form>
+</div>
+<?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/pages/invite.php
+++ b/it490/pages/invite.php
@@ -14,7 +14,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'sitter_email'     => trim($_POST['sitter_email']),
         'permission_level' => $_POST['permission_level'],
     ]);
-    $message = $resp['message'] ?? '';
+    if (($resp['status'] ?? '') === 'success') {
+        $message = ($resp['message'] ?? '') . ' Code: ' . ($resp['code'] ?? '');
+    } else {
+        $message = $resp['message'] ?? '';
+    }
 }
 // always fetch current list
 $list = sendMessage(['type'=>'invite_list','user_id'=>$user['id']]);

--- a/it490/pages/playdate_request.php
+++ b/it490/pages/playdate_request.php
@@ -2,11 +2,7 @@
 include_once __DIR__ . '/../auth.php';
 requireAuth();
 $user = $_SESSION['user'];
-<<<<<<< HEAD
-include_once __DIR__ . '/../includes/.mq_client.php';
-=======
 include_once __DIR__ . '/../includes/mq_client.php';
->>>>>>> 48f3e61 (modified playdates)
 
 // fetch requests
 $resp = sendMessage(['type'=>'playdate_requests_list','user_id'=>$user['id']]);

--- a/it490/pages/playdates.php
+++ b/it490/pages/playdates.php
@@ -23,12 +23,17 @@ $message = '';
 // handle create submission
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     try {
+        $scheduled = $_POST['scheduled_at'] ?? '';
+        if ($scheduled) {
+            $scheduled = str_replace('T', ' ', $scheduled);
+        }
+
         $resp = sendMessage([
             'type' => 'playdates_create',
             'user_id' => $user['id'],
             'title' => $_POST['title'] ?? '',
             'description' => $_POST['description'] ?? '',
-            'scheduled_at' => $_POST['scheduled_at'] ?? '',
+            'scheduled_at' => $scheduled,
             'location' => $_POST['location'] ?? '',
             'age_range' => $_POST['age_range'] ?? '',
             'size' => $_POST['size'] ?? '',

--- a/it490/send_user_request.php
+++ b/it490/send_user_request.php
@@ -37,6 +37,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['message'] = $resp['message'] ?? 'Failed to update request';
         }
         $redirect = '/pages/playdate_request.php';
+    } elseif ($type === 'lost_dogs_update') {
+        $resp = sendMessage([
+            'type' => 'lost_dogs_update',
+            'id' => $_POST['id'],
+            'status' => $_POST['status']
+        ]);
+
+        if ($resp['status'] === 'success') {
+            $_SESSION['message'] = 'Lost dog status updated.';
+        } else {
+            $_SESSION['message'] = $resp['message'] ?? 'Failed to update status';
+        }
+        $redirect = '/pages/lost_dogs.php';
     }
 
     header("Location: {$redirect}");

--- a/it490/send_user_request.php
+++ b/it490/send_user_request.php
@@ -7,7 +7,8 @@ include_once __DIR__ . '/includes/mq_client.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $type = $_GET['type'] ?? '';
-    
+    $redirect = '/pages/playdates.php';
+
     if ($type === 'playdate_request') {
         $resp = sendMessage([
             'type' => 'playdate_request',
@@ -17,13 +18,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             'location_preference' => $_POST['location_preference'],
             'custom_message' => $_POST['custom_message'] ?? ''
         ]);
-        
+
         if ($resp['status'] === 'success') {
             $_SESSION['message'] = 'Playdate request sent successfully!';
         } else {
             $_SESSION['message'] = $resp['message'] ?? 'Failed to send request';
         }
+    } elseif ($type === 'playdate_requests_update') {
+        $resp = sendMessage([
+            'type' => 'playdate_requests_update',
+            'id' => $_POST['id'],
+            'status' => $_POST['status']
+        ]);
+
+        if ($resp['status'] === 'success') {
+            $_SESSION['message'] = 'Playdate request updated.';
+        } else {
+            $_SESSION['message'] = $resp['message'] ?? 'Failed to update request';
+        }
+        $redirect = '/pages/playdate_request.php';
     }
+
+    header("Location: {$redirect}");
+    exit();
 }
 
 header('Location: /pages/playdates.php');

--- a/it490/workers/mq_worker.php
+++ b/it490/workers/mq_worker.php
@@ -293,10 +293,10 @@ $callback = function ($msg) use ($channel, $conn) {
                     );
                     if ($stmt->execute()) {
                         $response = ['status' => 'success', 'message' => 'Invite created', 'code' => $code, 'id' => $stmt->insert_id];
-                        echo "Invite created for dog {$payload['dog_id']}\n";
+                        echo " [+] Invite created for dog {$payload['dog_id']}\n";
                     } else {
                         $response['message'] = 'Failed to create invite: ' . $conn->error;
-                        echo "Invite creation failed\n";
+                        echo " [-] Invite creation failed\n";
                     }
                     break;
 
@@ -305,8 +305,10 @@ $callback = function ($msg) use ($channel, $conn) {
                     $stmt->bind_param('i', $payload['user_id']);
                     if ($stmt->execute()) {
                         $response = ['status' => 'success', 'invites' => $stmt->get_result()->fetch_all(MYSQLI_ASSOC)];
+                        echo " [x] Invite list fetched for user {$payload['user_id']}\n";
                     } else {
                         $response['message'] = 'Failed to fetch invites: ' . $conn->error;
+                        echo " [-] Invite list fetch failed\n";
                     }
                     break;
 
@@ -330,10 +332,10 @@ $callback = function ($msg) use ($channel, $conn) {
                     }
                     if ($stmt->execute()) {
                         $response = ['status' => 'success', 'message' => 'Invite updated'];
-                        echo "Invite updated to {$payload['status']}\n";
+                        echo " [+] Invite updated to {$payload['status']}\n";
                     } else {
                         $response['message'] = 'Failed to update invite: ' . $conn->error;
-                        echo "Invite update failed\n";
+                        echo " [-] Invite update failed\n";
                     }
                     break;
 
@@ -354,33 +356,34 @@ $callback = function ($msg) use ($channel, $conn) {
              	    	$payload['photo_url'],
             	    	$payload['user_id']
         	    );
-        	    if ($stmt->execute()){
-        	        $response = ['status'=>'success','message'=>'Lost dog reported'];
-			echo "Lost dog post added for {$payload['dog_id']}\n";
-		    } else {
-			$response['message'] = 'Failed to post lost dog report: ' . $conn->error;
-			echo "Report failed to post\n";
-		    }
-        	    break;
+                    if ($stmt->execute()){
+                        $response = ['status'=>'success','message'=>'Lost dog reported'];
+                        echo " [+] Lost dog post added for {$payload['dog_id']}\n";
+                    } else {
+                        $response['message'] = 'Failed to post lost dog report: ' . $conn->error;
+                        echo " [-] Lost dog report failed\n";
+                    }
+                    break;
 
-    		case 'lost_dogs_list':
-        	    $res = $conn->query("SELECT * FROM lost_dogs ORDER BY reported_at DESC");
-        	    $response = ['status'=>'success','alerts'=>$res->fetch_all(MYSQLI_ASSOC)];
-        	    break;
+                case 'lost_dogs_list':
+                    $res = $conn->query("SELECT * FROM lost_dogs ORDER BY reported_at DESC");
+                    $response = ['status'=>'success','alerts'=>$res->fetch_all(MYSQLI_ASSOC)];
+                    echo " [x] Lost dog alerts listed\n";
+                    break;
 
     		case 'lost_dogs_update':
         	    $stmt = $conn->prepare(
             		"UPDATE lost_dogs SET status = ? WHERE id = ?"
         	    );
         	    $stmt->bind_param('si',$payload['status'],$payload['id']);
-        	    if ($stmt->execute()){
-        	        $response = ['status'=>'success','message'=>'Alert updated'];
-			echo "Alert updated for {$payload['id']} to {$payload['status']}\n";
-		    } else {
-			$response['message'] = 'Status not updated: ' . $conn->error;
-			echo "Lost status not updated\n";
-        	    }
-        	    break;
+                    if ($stmt->execute()){
+                        $response = ['status'=>'success','message'=>'Alert updated'];
+                        echo " [+] Alert updated for {$payload['id']} to {$payload['status']}\n";
+                    } else {
+                        $response['message'] = 'Status not updated: ' . $conn->error;
+                        echo " [-] Lost status not updated\n";
+                    }
+                    break;
 
 		case 'playdates_list':
     		   $allowed = ['age_range','size','energy_level','temperament','play_style','gender_pref','location'];
@@ -410,14 +413,14 @@ $callback = function ($msg) use ($channel, $conn) {
     		   if ($clauses) {
         	   $stmt->bind_param($types, ...$params);
     		   }
-    		   if ($stmt->execute()){
-    		       $response = ['status'=>'success', 'playdates'=>$stmt->get_result()->fetch_all(MYSQLI_ASSOC)];
-		       echo "Playdate list displayed\n";
-		   } else {
-		       $response['message'] = 'List did not fetch: ' . $conn->error;
-		       echo "Playdates were not filtered\n";
-    		   }
-    		   break;
+                   if ($stmt->execute()){
+                       $response = ['status'=>'success', 'playdates'=>$stmt->get_result()->fetch_all(MYSQLI_ASSOC)];
+                       echo " [x] Playdate list displayed\n";
+                   } else {
+                       $response['message'] = 'List did not fetch: ' . $conn->error;
+                       echo " [-] Playdate list fetch failed\n";
+                   }
+                   break;
 
 		case 'playdates_create':
     		    $stmt = $conn->prepare("INSERT INTO PLAYDATES (created_by, title, description, scheduled_at, location, age_range, size, energy_level, temperament, play_style, gender_pref) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
@@ -466,8 +469,10 @@ $callback = function ($msg) use ($channel, $conn) {
                 $stmt->bind_param("i", $payload['user_id']);
                 if ($stmt->execute()) {
                     $response = ['status' => 'success', 'requests' => $stmt->get_result()->fetch_all(MYSQLI_ASSOC)];
+                    echo " [x] Playdate requests listed for user {$payload['user_id']}\n";
                 } else {
                     $response = ['status' => 'error', 'message' => 'Failed to fetch requests: ' . $conn->error];
+                    echo " [-] Playdate request list failed\n";
                 }
                 break;
 

--- a/it490/workers/mq_worker.php
+++ b/it490/workers/mq_worker.php
@@ -276,10 +276,70 @@ $callback = function ($msg) use ($channel, $conn) {
                     $waterEntries = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
                     $response = ['status' => 'success', 'entries' => $waterEntries];
                     break;
-		
-		case 'lost_dogs_create':
-        	    $stmt = $conn->prepare(
-            	    "INSERT INTO lost_dogs
+
+                case 'invite_create':
+                    $code = bin2hex(random_bytes(4));
+                    $stmt = $conn->prepare(
+                        "INSERT INTO SITTER_INVITES (owner_id,dog_id,sitter_email,permission_level,code,status,expires_at) " .
+                        "VALUES (?,?,?,?,?,'pending', DATE_ADD(NOW(), INTERVAL 7 DAY))"
+                    );
+                    $stmt->bind_param(
+                        'iisss',
+                        $payload['user_id'],
+                        $payload['dog_id'],
+                        $payload['sitter_email'],
+                        $payload['permission_level'],
+                        $code
+                    );
+                    if ($stmt->execute()) {
+                        $response = ['status' => 'success', 'message' => 'Invite created', 'code' => $code, 'id' => $stmt->insert_id];
+                        echo "Invite created for dog {$payload['dog_id']}\n";
+                    } else {
+                        $response['message'] = 'Failed to create invite: ' . $conn->error;
+                        echo "Invite creation failed\n";
+                    }
+                    break;
+
+                case 'invite_list':
+                    $stmt = $conn->prepare("SELECT id,code,dog_id,sitter_email,permission_level,status,expires_at FROM SITTER_INVITES WHERE owner_id = ? ORDER BY created_at DESC");
+                    $stmt->bind_param('i', $payload['user_id']);
+                    if ($stmt->execute()) {
+                        $response = ['status' => 'success', 'invites' => $stmt->get_result()->fetch_all(MYSQLI_ASSOC)];
+                    } else {
+                        $response['message'] = 'Failed to fetch invites: ' . $conn->error;
+                    }
+                    break;
+
+                case 'invite_update':
+                    if (!empty($payload['code'])) {
+                        if (!empty($payload['accepted_by'])) {
+                            $stmt = $conn->prepare("UPDATE SITTER_INVITES SET status = ?, accepted_by = ? WHERE code = ?");
+                            $stmt->bind_param('sis', $payload['status'], $payload['accepted_by'], $payload['code']);
+                        } else {
+                            $stmt = $conn->prepare("UPDATE SITTER_INVITES SET status = ? WHERE code = ?");
+                            $stmt->bind_param('ss', $payload['status'], $payload['code']);
+                        }
+                    } else {
+                        if (!empty($payload['accepted_by'])) {
+                            $stmt = $conn->prepare("UPDATE SITTER_INVITES SET status = ?, accepted_by = ? WHERE id = ?");
+                            $stmt->bind_param('sii', $payload['status'], $payload['accepted_by'], $payload['id']);
+                        } else {
+                            $stmt = $conn->prepare("UPDATE SITTER_INVITES SET status = ? WHERE id = ?");
+                            $stmt->bind_param('si', $payload['status'], $payload['id']);
+                        }
+                    }
+                    if ($stmt->execute()) {
+                        $response = ['status' => 'success', 'message' => 'Invite updated'];
+                        echo "Invite updated to {$payload['status']}\n";
+                    } else {
+                        $response['message'] = 'Failed to update invite: ' . $conn->error;
+                        echo "Invite update failed\n";
+                    }
+                    break;
+
+                case 'lost_dogs_create':
+                    $stmt = $conn->prepare(
+                    "INSERT INTO lost_dogs
                	       (dog_id,dog_name,description,last_lat,last_lng,alert_radius,photo_url,reported_by)
              	    VALUES(?,?,?,?,?,?,?,?)"
         	    );


### PR DESCRIPTION
## Summary
- add MQ worker handlers for sitter invites (create, list, update)
- surface invitation codes and add acceptance page for sitters
- enable playdate request updates and clean playdate request page

## Testing
- `php -l pages/playdate_request.php`
- `php -l send_user_request.php`
- `php -l workers/mq_worker.php`
- `php -l includes/mq_client.php`
- `php -l pages/invite.php`
- `php -l pages/accept_invite.php`


------
https://chatgpt.com/codex/tasks/task_e_688ff017362c8327aa1958308a523d01