### PR TITLE
Add playdate invite system for sitters

### DIFF
--- a/it490/includes/mq_client.php
+++ b/it490/includes/mq_client.php
@@ -154,6 +154,29 @@ function sendMessage(array $payload): array {
             }
             break;
 
+        case 'playdate_invites_create':
+            foreach (['user_id','playdate_id','invitee_id'] as $f) {
+                if (empty($payload[$f])) {
+                    throw new InvalidArgumentException("$f is required");
+                }
+            }
+            $payload['message'] = $payload['message'] ?? '';
+            break;
+
+        case 'playdate_invites_list':
+            if (empty($payload['user_id'])) {
+                throw new InvalidArgumentException('user_id is required');
+            }
+            break;
+
+        case 'playdate_invites_update':
+            foreach (['id','status'] as $f) {
+                if (empty($payload[$f])) {
+                    throw new InvalidArgumentException("$f is required");
+                }
+            }
+            break;
+
         case 'lost_dogs_create':
             foreach (['user_id','dog_id','dog_name','last_lat','last_lng','alert_radius'] as $f) {
                 if (!isset($payload[$f]) || $payload[$f] === '') {

--- a/it490/pages/playdates.php
+++ b/it490/pages/playdates.php
@@ -20,40 +20,56 @@ $playdates = $resp['playdates'] ?? [];
 
 $message = '';
 
-// handle create submission
+// handle submissions
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
     try {
-        $scheduled = $_POST['scheduled_at'] ?? '';
-        if ($scheduled) {
-            $scheduled = str_replace('T', ' ', $scheduled);
-        }
+        if ($action === 'create_playdate') {
+            $scheduled = $_POST['scheduled_at'] ?? '';
+            if ($scheduled) {
+                $scheduled = str_replace('T', ' ', $scheduled);
+            }
 
-        $resp = sendMessage([
-            'type' => 'playdates_create',
-            'user_id' => $user['id'],
-            'title' => $_POST['title'] ?? '',
-            'description' => $_POST['description'] ?? '',
-            'scheduled_at' => $scheduled,
-            'location' => $_POST['location'] ?? '',
-            'age_range' => $_POST['age_range'] ?? '',
-            'size' => $_POST['size'] ?? '',
-            'energy_level' => $_POST['energy_level'] ?? '',
-            'temperament' => $_POST['temperament'] ?? '',
-            'play_style' => $_POST['play_style'] ?? '',
-            'gender_pref' => $_POST['gender_pref'] ?? '',
-        ]);
-        
-        // Redirect to prevent resubmission
-        if ($resp['status'] === 'success') {
-            header('Location: /it490/pages/playdates.php?success=1');
-            exit();
-        } else {
-            $message = $resp['message'] ?? 'Failed to create playdate';
+            $resp = sendMessage([
+                'type' => 'playdates_create',
+                'user_id' => $user['id'],
+                'title' => $_POST['title'] ?? '',
+                'description' => $_POST['description'] ?? '',
+                'scheduled_at' => $scheduled,
+                'location' => $_POST['location'] ?? '',
+                'age_range' => $_POST['age_range'] ?? '',
+                'size' => $_POST['size'] ?? '',
+                'energy_level' => $_POST['energy_level'] ?? '',
+                'temperament' => $_POST['temperament'] ?? '',
+                'play_style' => $_POST['play_style'] ?? '',
+                'gender_pref' => $_POST['gender_pref'] ?? '',
+            ]);
+
+            // Redirect to prevent resubmission
+            if ($resp['status'] === 'success') {
+                header('Location: /it490/pages/playdates.php?success=1');
+                exit();
+            } else {
+                $message = $resp['message'] ?? 'Failed to create playdate';
+            }
+        } elseif ($action === 'create_invite') {
+            $resp = sendMessage([
+                'type' => 'playdate_invites_create',
+                'user_id' => $user['id'],
+                'playdate_id' => (int)($_POST['playdate_id'] ?? 0),
+                'invitee_id' => (int)($_POST['invitee_id'] ?? 0),
+                'message' => $_POST['message'] ?? ''
+            ]);
+            $message = $resp['message'] ?? '';
         }
     } catch (Exception $e) {
         $message = "An error occurred: " . $e->getMessage();
     }
 }
+
+// fetch invites for current user
+$invResp = sendMessage(['type' => 'playdate_invites_list', 'user_id' => $user['id']]);
+$invites = $invResp['invites'] ?? [];
 
 $title = 'Playdates';
 include_once __DIR__ . '/../header.php';
@@ -81,6 +97,7 @@ include_once __DIR__ . '/../header.php';
 
   <h2>Create New Playdate</h2>
   <form method="POST" class="form">
+    <input type="hidden" name="action" value="create_playdate">
     <input name="title" placeholder="Title" class="input" required>
     <input name="scheduled_at" type="datetime-local" class="input" required>
     <input name="location" placeholder="Location" class="input" required>
@@ -108,8 +125,48 @@ include_once __DIR__ . '/../header.php';
         <input name="custom_message" placeholder="Message" class="input">
         <button type="submit" class="btn small">Request</button>
       </form>
+      <form method="POST" class="form-inline" style="margin-top:5px;">
+        <input type="hidden" name="action" value="create_invite">
+        <input type="hidden" name="playdate_id" value="<?= htmlspecialchars($p['id']) ?>">
+        <input name="invitee_id" placeholder="Invite User ID" required class="input">
+        <input name="message" placeholder="Message" class="input">
+        <button type="submit" class="btn small">Invite</button>
+      </form>
     </li>
     <?php endforeach; ?>
   </ul>
-</div>
-<?php include_once __DIR__ . '/../footer.php'; ?>
+  
+  <h2>Your Playdate Invitations</h2>
+  <?php if (empty($invites)): ?>
+    <p>No invitations at this time.</p>
+  <?php else: ?>
+  <table class="table">
+    <thead>
+      <tr><th>Playdate</th><th>From</th><th>Message</th><th>Status</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+      <?php foreach ($invites as $i): ?>
+      <tr>
+        <td><?= htmlspecialchars($i['title']) ?></td>
+        <td><?= htmlspecialchars($i['inviter_id']) ?></td>
+        <td><?= htmlspecialchars($i['message']) ?></td>
+        <td><?= htmlspecialchars($i['status']) ?></td>
+        <td>
+          <?php if ($i['status'] === 'pending'): ?>
+          <form method="POST" action="../send_user_request.php?type=playdate_invites_update" class="form-inline">
+            <input type="hidden" name="id" value="<?= htmlspecialchars($i['id']) ?>">
+            <button name="status" value="accepted" class="btn small">Accept</button>
+            <button name="status" value="declined" class="btn small">Decline</button>
+          </form>
+          <?php else: ?>
+          --
+          <?php endif; ?>
+        </td>
+      </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+  <?php endif; ?>
+
+  </div>
+  <?php include_once __DIR__ . '/../footer.php'; ?>

--- a/it490/schema_playdate_invites.sql
+++ b/it490/schema_playdate_invites.sql
@@ -1,0 +1,13 @@
+CREATE TABLE PLAYDATE_INVITES (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    inviter_id INT NOT NULL,
+    invitee_id INT NOT NULL,
+    playdate_id INT NOT NULL,
+    message VARCHAR(255) DEFAULT '',
+    status ENUM('pending','accepted','declined') DEFAULT 'pending',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    responded_at DATETIME NULL,
+    FOREIGN KEY (inviter_id) REFERENCES USERS(id),
+    FOREIGN KEY (invitee_id) REFERENCES USERS(id),
+    FOREIGN KEY (playdate_id) REFERENCES PLAYDATES(id)
+);

--- a/it490/send_user_request.php
+++ b/it490/send_user_request.php
@@ -37,6 +37,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION['message'] = $resp['message'] ?? 'Failed to update request';
         }
         $redirect = '/pages/playdate_request.php';
+    } elseif ($type === 'playdate_invites_update') {
+        $resp = sendMessage([
+            'type' => 'playdate_invites_update',
+            'id' => $_POST['id'],
+            'status' => $_POST['status']
+        ]);
+
+        if ($resp['status'] === 'success') {
+            $_SESSION['message'] = 'Playdate invitation updated.';
+        } else {
+            $_SESSION['message'] = $resp['message'] ?? 'Failed to update invitation';
+        }
+        $redirect = '/pages/playdates.php';
     } elseif ($type === 'lost_dogs_update') {
         $resp = sendMessage([
             'type' => 'lost_dogs_update',

--- a/it490/workers/mq_worker.php
+++ b/it490/workers/mq_worker.php
@@ -437,18 +437,54 @@ $callback = function ($msg) use ($channel, $conn) {
     		        $payload['play_style'],
     		        $payload['gender_pref']
     		    );
-    		    if ($stmt->execute()) {
-    		        $response = ['status' => 'success', 'message' => 'Playdate created'];
-    		        echo " [+] Playdate created for user {$payload['user_id']}\n";
-    		    } else {
-    		        $response = ['status' => 'error', 'message' => 'Failed to create playdate: ' . $conn->error];
-    		        echo " [-] Playdate creation failed\n";
-    		    }
-    		    break;
+                    if ($stmt->execute()) {
+                        $response = ['status' => 'success', 'message' => 'Playdate created'];
+                        echo " [+] Playdate created for user {$payload['user_id']}\n";
+                    } else {
+                        $response = ['status' => 'error', 'message' => 'Failed to create playdate: ' . $conn->error];
+                        echo " [-] Playdate creation failed\n";
+                    }
+                    break;
+
+            case 'playdate_invites_create':
+                $stmt = $conn->prepare("INSERT INTO PLAYDATE_INVITES (inviter_id, invitee_id, playdate_id, message) VALUES (?,?,?,?)");
+                $stmt->bind_param('iiis', $payload['user_id'], $payload['invitee_id'], $payload['playdate_id'], $payload['message']);
+                if ($stmt->execute()) {
+                    $response = ['status' => 'success', 'message' => 'Invitation sent'];
+                    echo " [+] Playdate invite from {$payload['user_id']} to {$payload['invitee_id']}\\n";
+                } else {
+                    $response = ['status' => 'error', 'message' => 'Failed to send invite: ' . $conn->error];
+                    echo " [-] Playdate invite failed\\n";
+                }
+                break;
+
+            case 'playdate_invites_list':
+                $stmt = $conn->prepare("SELECT pi.id, pi.playdate_id, pi.inviter_id, pi.message, pi.status, p.title FROM PLAYDATE_INVITES pi JOIN PLAYDATES p ON pi.playdate_id = p.id WHERE pi.invitee_id = ? ORDER BY pi.created_at DESC");
+                $stmt->bind_param('i', $payload['user_id']);
+                if ($stmt->execute()) {
+                    $response = ['status' => 'success', 'invites' => $stmt->get_result()->fetch_all(MYSQLI_ASSOC)];
+                    echo " [x] Playdate invites listed for user {$payload['user_id']}\\n";
+                } else {
+                    $response = ['status' => 'error', 'message' => 'Failed to fetch invites: ' . $conn->error];
+                    echo " [-] Playdate invites list failed\\n";
+                }
+                break;
+
+            case 'playdate_invites_update':
+                $stmt = $conn->prepare("UPDATE PLAYDATE_INVITES SET status = ?, responded_at = NOW() WHERE id = ?");
+                $stmt->bind_param('si', $payload['status'], $payload['id']);
+                if ($stmt->execute()) {
+                    $response = ['status' => 'success', 'message' => 'Invitation updated'];
+                    echo " [+] Playdate invite {$payload['id']} updated to {$payload['status']}\\n";
+                } else {
+                    $response = ['status' => 'error', 'message' => 'Failed to update invite: ' . $conn->error];
+                    echo " [-] Playdate invite update failed\\n";
+                }
+                break;
 
             case 'playdate_request':
                 $stmt = $conn->prepare("INSERT INTO PLAYDATE_REQUESTS (requester_id, target_owner_id, dog_size_match, location_preference, custom_message) VALUES (?, ?, ?, ?, ?)");
-                $stmt->bind_param("iisss", 
+                $stmt->bind_param("iisss",
                     $payload['user_id'],
                     $payload['target_owner_id'],
                     $payload['dog_size_match'],


### PR DESCRIPTION
## Summary
- store playdate invitations in new `PLAYDATE_INVITES` table
- support creating, listing, and updating playdate invitations via MQ worker and client
- display pending playdate invites with accept/decline actions on playdates page

## Testing
- `php -l includes/mq_client.php pages/playdates.php send_user_request.php workers/mq_worker.php`

------
https://chatgpt.com/codex/tasks/task_e_68900b87a668832787dde1b1f9cbabbf